### PR TITLE
[Fix] CardDataSO에 대상 색상 필드 추가

### DIFF
--- a/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
+++ b/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
@@ -47,7 +47,7 @@ public class CardDataSOEditor : Editor
         cardType = serializedObject.FindProperty("Type");
 
         pieceType = serializedObject.FindProperty("PieceType");
-        targetColorPiece = serializedObject.FindProperty("TargetColor");
+        targetColorPiece = serializedObject.FindProperty("PieceTargetColor");
         pieceLimitTurn = serializedObject.FindProperty("PieceLimitTurn");
         requiredPieceCount = serializedObject.FindProperty("RequiredPieceCount");
 
@@ -55,7 +55,7 @@ public class CardDataSOEditor : Editor
         maintainTurn = serializedObject.FindProperty("MaintainTurn");
 
         needTargetColor = serializedObject.FindProperty("NeedTargetColor");
-        targetColor = serializedObject.FindProperty("_TargetColor");
+        targetColor = serializedObject.FindProperty("GlobalTargetColor");
         hasLimit = serializedObject.FindProperty("HasLimit");
         limitTurn = serializedObject.FindProperty("LimitTurn");
 

--- a/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
+++ b/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
@@ -12,6 +12,7 @@ public class CardDataSOEditor : Editor
 
     // 기물 타입
     SerializedProperty pieceType;
+    SerializedProperty targetColorPiece;
     SerializedProperty pieceLimitTurn;
     SerializedProperty requiredPieceCount;
 
@@ -20,6 +21,8 @@ public class CardDataSOEditor : Editor
     SerializedProperty maintainTurn;
 
     // 전역 타입
+    SerializedProperty needTargetColor;
+    SerializedProperty targetColor;
     SerializedProperty hasLimit;
     SerializedProperty limitTurn;
 
@@ -44,12 +47,15 @@ public class CardDataSOEditor : Editor
         cardType = serializedObject.FindProperty("Type");
 
         pieceType = serializedObject.FindProperty("PieceType");
+        targetColorPiece = serializedObject.FindProperty("TargetColor");
         pieceLimitTurn = serializedObject.FindProperty("PieceLimitTurn");
         requiredPieceCount = serializedObject.FindProperty("RequiredPieceCount");
 
         tileCount = serializedObject.FindProperty("TileCount");
         maintainTurn = serializedObject.FindProperty("MaintainTurn");
 
+        needTargetColor = serializedObject.FindProperty("NeedTargetColor");
+        targetColor = serializedObject.FindProperty("_TargetColor");
         hasLimit = serializedObject.FindProperty("HasLimit");
         limitTurn = serializedObject.FindProperty("LimitTurn");
 
@@ -139,6 +145,7 @@ public class CardDataSOEditor : Editor
         HelpBox("기물 카드: 특정 기물을 배치하거나 조합하는 카드입니다.", MessageType.None);
         EditorGUILayout.Space(2);
         EditorGUILayout.PropertyField(pieceType, new GUIContent("기물 종류"));
+        EditorGUILayout.PropertyField(targetColorPiece, new GUIContent("대상 색상"));
         EditorGUILayout.PropertyField(pieceLimitTurn, new GUIContent("효과 유지 턴"));
         if (pieceLimitTurn.intValue == -1)
         {
@@ -164,6 +171,15 @@ public class CardDataSOEditor : Editor
     {
         HelpBox("전역 카드: 게임 전체에 영향을 주는 카드입니다.", MessageType.None);
         EditorGUILayout.Space(2);
+        EditorGUILayout.PropertyField(needTargetColor, new GUIContent("대상 색상 필요"));
+        if (needTargetColor.boolValue)
+        {
+            EditorGUI.indentLevel++;
+            EditorGUILayout.PropertyField(targetColor, new GUIContent("대상 색상"));
+            EditorGUI.indentLevel--;
+        }
+
+        EditorGUILayout.Space(4);
         EditorGUILayout.PropertyField(hasLimit, new GUIContent("턴 제한 여부"));
 
         if (hasLimit.boolValue)

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -15,6 +15,10 @@ public class CardDataSO : ScriptableObject
     [Space(30)]
     [Header("기물 타입 설정")]
     public PieceType PieceType;
+    /// <summary>
+    /// 기물 타입에서의 대상 색깔
+    /// </summary>
+    public PieceColor TargetColor;
     [Range(-1, 10)]
     public int PieceLimitTurn;
     public int RequiredPieceCount;
@@ -32,6 +36,11 @@ public class CardDataSO : ScriptableObject
     [Space(30)]
     [Header("전역 타입 설정")]
     //전역 타입에 필요한 설정
+    public bool NeedTargetColor;
+    /// <summary>
+    /// 전역 타입에서의 대상 색깔
+    /// </summary>
+    public PieceColor _TargetColor;
     public bool HasLimit;
     public int LimitTurn;
 

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -18,7 +18,7 @@ public class CardDataSO : ScriptableObject
     /// <summary>
     /// 기물 타입에서의 대상 색깔
     /// </summary>
-    public PieceColor TargetColor;
+    public PieceColor PieceTargetColor;
     [Range(-1, 10)]
     public int PieceLimitTurn;
     public int RequiredPieceCount;
@@ -40,7 +40,7 @@ public class CardDataSO : ScriptableObject
     /// <summary>
     /// 전역 타입에서의 대상 색깔
     /// </summary>
-    public PieceColor _TargetColor;
+    public PieceColor GlobalTargetColor;
     public bool HasLimit;
     public int LimitTurn;
 

--- a/ChaosChess_v2/Assets/Script/Card/SO/DimensionDisturbanceCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/DimensionDisturbanceCard.asset
@@ -17,10 +17,13 @@ MonoBehaviour:
   CardDescription: "\uCC28\uC6D0\uAD50\uB780"
   Type: 0
   PieceType: 15
+  TargetColor: 1
   PieceLimitTurn: -1
   RequiredPieceCount: 2
   TileCount: 0
   MaintainTurn: 0
+  NeedTargetColor: 0
+  _TargetColor: 0
   HasLimit: 0
   LimitTurn: 0
   NeedAdditionalDescription: 0

--- a/ChaosChess_v2/Assets/Script/Card/SO/ShuffleBoardCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ShuffleBoardCard.asset
@@ -18,10 +18,13 @@ MonoBehaviour:
     \uC704\uCE58\uB97C \uC804\uBD80 \uC11E\uC2B5\uB2C8\uB2E4."
   Type: 2
   PieceType: 0
+  TargetColor: 0
   PieceLimitTurn: 0
   RequiredPieceCount: 0
   TileCount: 0
   MaintainTurn: 0
+  NeedTargetColor: 1
+  _TargetColor: 1
   HasLimit: 0
   LimitTurn: 0
   NeedAdditionalDescription: 0

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -41,9 +41,12 @@ public class PieceSelector : Selector<Piece>
 
             Piece p = boardManager.GetPiece(mouseGridPos);
 
+            // 널 체크
             if (p != null)
             {
-                if((p.Type & cardData.DataSO.PieceType) != 0)
+                // 기물 타입과 색상 체크
+                if((p.Type & cardData.DataSO.PieceType) != 0 &&
+                    p.Color == cardData.DataSO.TargetColor)
                 {
                     SelectTarget(p);
                 }


### PR DESCRIPTION
# 개요

- 기존 CardDataSO에 대상 색상이 명시되어 있지 않아 상대 기물도 선택할 수 있었던 오류를 수정하였습니다.
- PieceSelector에 기물 타입을 체크하는 조건문을 추가하였습니다.