### PR TITLE
[feature] 무하한 스킬 카드 구현 완료

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
@@ -3337,7 +3337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd9cc2e5015fe2048b92607aa98cc663, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardType: 2
+  cardType: 0
 --- !u!114 &1507320768
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3347,10 +3347,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507320761}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 82438e0efe58f4e40a23a94fa3e08d62, type: 3}
+  m_Script: {fileID: 11500000, guid: 3330d3a00fa3f2342b38d346fbd2a365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DataSO: {fileID: 11400000, guid: b35d3d8eec463c94fb78531de01521e5, type: 2}
+  DataSO: {fileID: 11400000, guid: 3b644af4b8b478b4ea91d55467cd65bd, type: 2}
 --- !u!1 &1567853222
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -79,6 +79,7 @@ public abstract class TileEffector : Effector, ITileEffect
 
     public virtual void OnPieceEnter(Piece piece) { }
     public virtual void OnPieceExit(Piece piece) { }
+    public virtual bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to) { return true; }
 }
 
 /// <summary>특정 타입의 기물이 행동(이동/잡기)했을 때 반응하는 전역 효과의 기반 추상 클래스</summary>

--- a/ChaosChess_v2/Assets/Script/Card/Effector/IEffect.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/IEffect.cs
@@ -16,4 +16,5 @@ public interface ITileEffect : IEffect
 {
     void OnPieceEnter(Piece piece);
     void OnPieceExit(Piece piece);
+    bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to);
 }

--- a/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fd1d52bc7835dc49a6852a596f9c1f0, type: 3}
+  m_Name: LimitlessCard
+  m_EditorClassIdentifier: 
+  CardName: "\uBB34\uD558\uD55C"
+  CardImage: {fileID: 0}
+  CardDescription: "\uBC18\uACBD 1\uCE78 \uB0B4\uB85C \uC5B4\uB5A0\uD55C \uAE30\uBB3C\uB3C4
+    \uC811\uADFC/\uC774\uB3D9\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4. (\uC774 \uAE30\uBBF9\uC774
+    \uC801\uC6A9\uB41C \uAE30\uBB3C\uC740 \uC6C0\uC9C1\uC77C \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.)
+    \u2190 \uBB34\uC81C\uD55C, \uC0C1\uB300/\uC544\uAD70\uC774 \uB4E4\uC5B4\uC624\uB824\uACE0
+    \uC2DC\uB3C4\uD558\uBA74 \uC218\uB97C \uCDE8\uC18C\uD558\uACE0 \uD574\uC81C."
+  Type: 0
+  CardTier: 1
+  PieceType: -1
+  PieceTargetColor: 0
+  PieceLimitTurn: -1
+  RequiredPieceCount: 1
+  TileCount: 0
+  MaintainTurn: 0
+  RestrictTiles: 0
+  BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  NeedTargetColor: 0
+  GlobalTargetColor: 0
+  HasLimit: 0
+  LimitTurn: 0
+  NeedAdditionalDescription: 0
+  DescriptionType: 0

--- a/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset.meta
+++ b/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b644af4b8b478b4ea91d55467cd65bd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 무하한 카드
+/// 반경 1칸 내로 어떠한 기물도 접근/이동할 수 없습니다. 
+/// (이 기믹이 적용된 기물은 움직일 수 없습니다.) ← 무제한, 상대/아군이 들어오려고 시도하면 수를 취소하고 해제.
+/// </summary>
+public class LimitlessCard : CardData, IPieceCard
+{
+    private PieceSelector selector;
+
+    private void Awake()
+    {
+        selector = FindFirstObjectByType<PieceSelector>();
+    }
+
+    public void LoadPieceSelector()
+    {
+        if (selector == null)
+            selector = FindFirstObjectByType<PieceSelector>();
+
+        selector.EnableSelector(this);
+    }
+
+    public void Execute(CardEffectArgs args = null)
+    {
+        Piece piece = args.Targets[0];
+
+        // 기물 효과 적용 (움직임 제한 등)
+        var pieceEffector = CreatePieceEffector<LimitlessPieceEffector>(piece);
+        pieceEffector.Apply();
+
+        // 3x3 필드 생성
+        CreateLimitlessField(piece, pieceEffector);
+    }
+
+    private void CreateLimitlessField(Piece center, LimitlessPieceEffector pieceEff)
+    {
+        Vector3Int pos = center.Pos;
+
+        var controller = new LimitlessFieldController(pieceEff);
+
+        for (int dx = -1; dx <= 1; dx++)
+        {
+            for (int dy = -1; dy <= 1; dy++)
+            {
+                Vector3Int tile = new Vector3Int(pos.x + dx, pos.y + dy, 0);
+
+                if (!BoardManager.Instance.IsInside(tile))
+                    continue;
+
+                GameObject obj = new GameObject("LimitlessTile");
+                var eff = obj.AddComponent<LimitlessTileEffector>();
+
+                eff.Init(tile, -1);
+                eff.SetController(controller);
+                eff.Apply();
+
+                controller.tiles.Add(eff);
+            }
+        }
+    }
+}
+
+public class LimitlessPieceEffector : PieceEffector
+{
+    protected override void OnApply()
+    {
+        target.FenOverride = "a";
+        BoardManager.Instance.RefreshMoves();
+    }
+
+    protected override void OnRevert()
+    {
+        target.FenOverride = null;
+        BoardManager.Instance.RefreshMoves();
+        Destroy(this);
+    }
+}
+
+/// <summary>
+/// 무하한이 적용된 3x3타일들을 관리합니다
+/// </summary>
+public class LimitlessFieldController
+{
+    public List<LimitlessTileEffector> tiles = new();
+    private LimitlessPieceEffector pieceEff;
+
+    private bool broken = false;
+
+    public LimitlessFieldController(LimitlessPieceEffector pieceEff)
+    {
+        this.pieceEff = pieceEff;
+    }
+
+    public void Break()
+    {
+        if (broken) return;
+        broken = true;
+
+        // 1. 타일 제거
+        foreach (var t in tiles)
+        {
+            if (t != null)
+                t.Revert();
+        }
+        tiles.Clear();
+
+        // 2. 기물 효과 제거
+        if (pieceEff != null)
+            pieceEff.Revert();
+    }
+}
+
+public class LimitlessTileEffector : TileEffector
+{
+    private LimitlessFieldController controller;
+
+    public void SetController(LimitlessFieldController controller)
+    {
+        this.controller = controller;
+    }
+
+    protected override void OnApply()
+    {
+        BoardManager.Instance.RegisterTileEffector(tilePos, this);
+    }
+
+    protected override void OnRevert()
+    {
+        BoardManager.Instance.UnregisterTileEffector(tilePos, this);
+        Destroy(gameObject);
+    }
+
+    public override bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to)
+    {
+        // 진입 시도 → 필드 전체 제거
+        controller?.Break();
+
+        return false; // 이동 차단
+    }
+}

--- a/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs.meta
+++ b/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3330d3a00fa3f2342b38d346fbd2a365

--- a/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
@@ -33,17 +33,16 @@ public class WindmillCard : CardData, IPieceCard
 public class WindmillEffector : PieceEffector
 {
     public string change;
-    public override void Apply()
+    protected override void OnApply()
     {
         target.FenOverride = change;
         BoardManager.Instance.RefreshMoves();
     }
 
-    public override void Revert()
+    protected override void OnRevert()
     {
         target.FenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }
-
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -680,6 +680,18 @@ public class BoardManager : MonoBehaviour
     {
         Vector3Int from = piece.Pos;
 
+        if (!CanMoveToTile(piece, from, target))
+        {
+            if (useTurn)
+            {
+                GameManager.Instance.NextTurn();
+            }
+            else
+            {
+                RefreshMoves();
+            }
+        }
+
         TriggerTileExit(from, piece);
         board[from.x, from.y] = null;
 

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -311,6 +311,9 @@ public class BoardManager : MonoBehaviour
 
         Vector3Int from = piece.Pos;
 
+        if (!CanMoveToTile(piece, from, target))
+            return true; // 기물 이동을 안하고 턴을 넘김
+
         Vector3Int prevEP = enPassantPos;
         enPassantPos = new Vector3Int(-1, -1, -1);
 
@@ -607,6 +610,19 @@ public class BoardManager : MonoBehaviour
     public int GetHalfmoveClock()
     {
         return halfmoveClock;
+    }
+
+    private bool CanMoveToTile(Piece piece, Vector3Int from, Vector3Int to)
+    {
+        if (!tileEffectors.TryGetValue(to, out var list)) return true;
+
+        foreach (var effector in list)
+        {
+            if (!effector.CanPieceEnter(piece, from, to))
+                return false;
+        }
+
+        return true;
     }
 
     public void RegisterTileEffector(Vector3Int pos, TileEffector effector)

--- a/ChaosChess_v2/Assets/Script/Pieces/Amazon.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Amazon.cs
@@ -2,9 +2,13 @@ public class Amazon : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "S";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "s";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "S";
+            else return "s";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/Chancellor.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Chancellor.cs
@@ -2,9 +2,13 @@ public class Chancellor : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "Y";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "y";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "Y";
+            else return "y";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/King.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/King.cs
@@ -2,9 +2,13 @@ public class King : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "K";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "k";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "K";
+            else return "k";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/KnightRider.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/KnightRider.cs
@@ -2,9 +2,13 @@ public class KnightRider : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "Z";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "z";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "Z";
+            else return "z";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/Pawn.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Pawn.cs
@@ -2,9 +2,13 @@ public class Pawn : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "P";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "p";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "P";
+            else return "p";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/Queen.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Queen.cs
@@ -2,9 +2,13 @@ public class Queen : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "Q";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "q";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "Q";
+            else return "q";
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/Pieces/Wall.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Wall.cs
@@ -2,9 +2,13 @@ public class Wall : Piece
 {
     public override string GetFen()
     {
-        if (Color == PieceColor.White)
-            return "A";
+        if (FenOverride != null)
+            return FenOverride;
         else
-            return "a";
+        {
+            bool Upper = Color == PieceColor.White;
+            if (Upper) return "A";
+            else return "a";
+        }
     }
 }

--- a/ChaosChess_v2/ChaosChess_v2.slnx
+++ b/ChaosChess_v2/ChaosChess_v2.slnx
@@ -1,0 +1,5 @@
+﻿<Solution>
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-firstpass.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
+</Solution>


### PR DESCRIPTION
## 개요
무하한 스킬 카드를 구현하였습니다.
## 기타사항
기물 이동 처리 로직에 진입 전 검사(CanPieceEnter)를 추가하여, 
타일 효과에 의해 이동이 사전에 차단될 수 있도록 수정하였습니다.
특정 타일에 진입 시 이동을 취소하고 즉시 턴을 넘깁니다.