### PR TITLE
[Fix] 신속행군 스킬 카드 이펙터 사용하게 수정

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
@@ -3347,10 +3347,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507320761}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 49a9ea2ffbb407b4992f35dc89937666, type: 3}
+  m_Script: {fileID: 11500000, guid: d2329617aa12d594bb6546c1c1267434, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DataSO: {fileID: 11400000, guid: f3ac962e0a49f6849bfe623ab17dbccb, type: 2}
+  DataSO: {fileID: 11400000, guid: 88d8ee19855a5714a9bf52ea8fcc41d2, type: 2}
 --- !u!1 &1567853222
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
@@ -20,17 +20,29 @@ public class FastMarchCard : CardData, IPieceCard
     public void Execute(CardEffectArgs args = null)
     {
         Piece piece = args.Targets[0];
-        piece.MoveFenOverride = "q";
+        FastMarchCardEffector effector = CreatePieceEffector<FastMarchCardEffector>(piece);
+
+        effector.Apply(true);
+    }
+}
+
+public class FastMarchCardEffector : PieceEffector
+{
+    protected override void OnApply()
+    {
+        target.MoveFenOverride = "q";
+        BoardManager.Instance.RefreshMoves();
+    }
+
+    protected override void OnRevert()
+    {
+        target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 
-        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, () =>
-        {
-            ResetMoveFen(piece);
-        });
+        Destroy(this);
     }
-    public void ResetMoveFen(Piece piece)
+    protected override void OnHalfTurnChanged()
     {
-        piece.MoveFenOverride = null;
-        BoardManager.Instance.RefreshMoves();
+        Revert();
     }
 }


### PR DESCRIPTION
## 개요
신속행군 스킬 카드가 다음 턴에 효과가 사라지는것을 이펙터를 사용해서 동작하게 수정했습니다.