### PR TITLE
feat: 투기장 스킬 카드 구현

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/CardTestScene.unity
@@ -3337,7 +3337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd9cc2e5015fe2048b92607aa98cc663, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cardType: 0
+  cardType: 2
 --- !u!114 &1507320768
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3347,10 +3347,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 1507320761}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b4f5cd95489d0294eb49af36fa47eaab, type: 3}
+  m_Script: {fileID: 11500000, guid: 585ea241c0416734a93d11b210438685, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DataSO: {fileID: 11400000, guid: fde80858e1903f040aec8ec774cac6c5, type: 2}
+  DataSO: {fileID: 11400000, guid: 5386cf88badf52e4285efc816faebdc5, type: 2}
 --- !u!1 &1567853222
 GameObject:
   m_ObjectHideFlags: 0
@@ -4232,6 +4232,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   UIChessBoard: {fileID: 1170031624}
   SelectTile: {fileID: 11400000, guid: 9523c4d553996d148a094f0f3aab6732, type: 2}
+--- !u!1 &1920602517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1920602518}
+  - component: {fileID: 1920602519}
+  m_Layer: 0
+  m_Name: ArenaManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1920602518
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1920602517}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1920602519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1920602517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c348ec35ec64034fb16e3079b555922, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2040316850
 GameObject:
   m_ObjectHideFlags: 0
@@ -4466,3 +4510,4 @@ SceneRoots:
   - {fileID: 1155877494}
   - {fileID: 430042879}
   - {fileID: 1507320765}
+  - {fileID: 1920602518}

--- a/ChaosChess_v2/Assets/Script/Arena.meta
+++ b/ChaosChess_v2/Assets/Script/Arena.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f3c57df1161740489edacf2e213b7a3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public enum ArenaResult { PlayerWon, Timeout, OpponentCheckmated }
@@ -62,6 +63,7 @@ public class ArenaManager : MonoBehaviour
 
         BoardManager bm = BoardManager.Instance;
         GameManager gm = GameManager.Instance;
+        var allPiece = bm.GetAllPieces();
 
         // 아레나 시작 시 모든 기물 위치 저장 (Timeout 시 완전 복원에 사용)
         savedPositions.Clear();
@@ -73,8 +75,8 @@ public class ArenaManager : MonoBehaviour
         savedCastlingFen = bm.GetFEN().Split(' ')[2];
 
         // 양쪽 King 참조 저장 — Stockfish 연산에 필요
-        playerKing = bm.GetAllPieces().Find(p => p.Color == gm.PlayerColor && p.Type == PieceType.King);
-        opponentKing = bm.GetAllPieces().Find(p => p.Color == gm.EnemyColor && p.Type == PieceType.King);
+        playerKing = allPiece.Find(p => p.Color == gm.PlayerColor && p.Type == PieceType.King);
+        opponentKing = allPiece.Find(p => p.Color == gm.EnemyColor && p.Type == PieceType.King);
 
         // 플레이어 전체 기물 + 상대 arena 3개 + 상대 King 외 모든 기물을 보드에서 숨김
         // — 숨겨진 기물은 SetActive(false) + 보드 배열 제거로 Stockfish FEN에 포함되지 않음
@@ -82,7 +84,7 @@ public class ArenaManager : MonoBehaviour
             bm.GetAllPieces().FindAll(p => p.Color == gm.PlayerColor));
         keepPieces.UnionWith(opponents);
         keepPieces.Add(opponentKing); // playerKing은 플레이어 기물로 이미 포함됨
-        foreach (Piece p in bm.GetAllPieces())
+        foreach (Piece p in allPiece)
         {
             if (!keepPieces.Contains(p))
             {

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -1,0 +1,204 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public enum ArenaResult { PlayerWon, Timeout, OpponentCheckmated }
+
+/// <summary>
+/// 투기장 카드 효과를 관리하는 싱글턴 매니저.
+///
+/// [동작 원리]
+/// 1. StartArena() 호출 시 비투기장 기물을 보드에서 숨기고 (HidePiece)
+///    양쪽 King만 남겨 Stockfish가 정상적으로 수를 계산할 수 있도록 유지합니다.
+/// 2. King은 IsInvincible 상태로 설정해 포획되지 않도록 하며,
+///    매 반턴(OnHalfTurnChanged)마다 무적을 갱신합니다.
+/// 3. 플레이어 기물 전체가 이동 가능하며, 상대 기물은 Stockfish가 조종합니다.
+/// 4. 승패 조건이 충족되거나 8턴이 초과되면 EndArena()로 결과를 처리합니다.
+///
+/// [승패 조건]
+/// - PlayerWon        : 상대 투기장 기물 3개 모두 포획 → 해당 기물만 영구 제거
+/// - Timeout          : 8 플레이어 턴 초과 → 무효, 기물 복원 후 메인 게임 재개
+/// - OpponentCheckmated : 투기장 내 체크메이트 → 플레이어 게임 승리
+/// </summary>
+public class ArenaManager : MonoBehaviour
+{
+    public static ArenaManager Instance;
+
+    // 투기장 참가 기물
+    private List<Piece> opponentArenaPieces = new();  // 상대 투기장 기물 (최대 3개)
+
+    // 숨겨진 기물 목록 (투기장 종료 시 복원 대상)
+    private List<Piece> hiddenPieces = new();
+
+    // Stockfish 호환을 위해 보드에 남기는 King 참조
+    private Piece playerKing;
+    private Piece opponentKing;
+
+    private int playerMoveCount;  // 플레이어가 투기장에서 이동한 횟수 (최대 8)
+    private bool isArenaActive;   // 중복 StartArena / EndArena 호출 방지용 플래그
+
+    // Timeout 복원용: 아레나 시작 시점의 모든 기물 위치 스냅샷
+    private Dictionary<Piece, Vector3Int> savedPositions = new();
+    private string savedCastlingFen;  // 아레나 시작 시점의 캐슬링 권한 (Timeout 시 복원)
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+        else Destroy(gameObject);
+    }
+
+    /// <summary>
+    /// 투기장을 시작합니다.
+    /// </summary>
+    /// <param name="opponents">투기장에 참여할 상대 기물 목록 (최대 3개)</param>
+    public void StartArena(List<Piece> opponents)
+    {
+        if (isArenaActive) return;
+        isArenaActive = true;
+
+        opponentArenaPieces = opponents;
+        playerMoveCount = 0;
+        hiddenPieces.Clear();
+
+        BoardManager bm = BoardManager.Instance;
+        GameManager gm = GameManager.Instance;
+
+        // 아레나 시작 시 모든 기물 위치 저장 (Timeout 시 완전 복원에 사용)
+        savedPositions.Clear();
+        foreach (Piece p in bm.GetAllPieces())
+            savedPositions[p] = p.Pos;
+
+        // 캐슬링 권한 저장 — BatchReassign이 King/Rook 복원 시 플래그를 손상시키므로 별도 보존
+        bm.UpdateFEN();
+        savedCastlingFen = bm.GetFEN().Split(' ')[2];
+
+        // 양쪽 King 참조 저장 — Stockfish 연산에 필요
+        playerKing = bm.GetAllPieces().Find(p => p.Color == gm.PlayerColor && p.Type == PieceType.King);
+        opponentKing = bm.GetAllPieces().Find(p => p.Color == gm.EnemyColor && p.Type == PieceType.King);
+
+        // 플레이어 전체 기물 + 상대 arena 3개 + 상대 King 외 모든 기물을 보드에서 숨김
+        // — 숨겨진 기물은 SetActive(false) + 보드 배열 제거로 Stockfish FEN에 포함되지 않음
+        HashSet<Piece> keepPieces = new HashSet<Piece>(
+            bm.GetAllPieces().FindAll(p => p.Color == gm.PlayerColor));
+        keepPieces.UnionWith(opponents);
+        keepPieces.Add(opponentKing); // playerKing은 플레이어 기물로 이미 포함됨
+        foreach (Piece p in bm.GetAllPieces())
+        {
+            if (!keepPieces.Contains(p))
+            {
+                hiddenPieces.Add(p);
+                bm.HidePiece(p);
+            }
+        }
+
+        // King을 무적으로 설정 — Stockfish가 King 포획 시도 시 ConsumeInvincibility()로
+        // 실제 포획 없이 NextTurn()만 호출됨. 무적은 매 반턴 OnHalfTurnChanged에서 갱신됨
+        playerKing?.SetInvincible();
+        opponentKing?.SetInvincible();
+
+        // 투기장 모드 활성화 — 플레이어 기물 전체 이동 가능 (lockedPiece 없음)
+        // — IsArenaMode: EvaluateGameState()의 체크메이트/스테일메이트 판정 건너뜀
+        gm.IsArenaMode = true;
+        gm.SetLockedPiece(null);
+
+        // 반턴 이벤트 구독으로 포획 감지 및 턴 카운트
+        gm.OnHalfTurnChanged += OnHalfTurnChanged;
+    }
+
+    /// <summary>
+    /// 매 반턴 종료 시 호출됩니다.
+    /// King 무적 갱신, 포획 감지, 8턴 초과 판정을 수행합니다.
+    /// </summary>
+    private void OnHalfTurnChanged()
+    {
+        if (!isArenaActive) return;
+
+        // King 무적 갱신 — ApplyUCIMove에서 ConsumeInvincibility() 호출 후 재설정
+        playerKing?.SetInvincible();
+        opponentKing?.SetInvincible();
+
+        // 상대 투기장 기물 전멸 여부 확인
+        if (opponentArenaPieces.Count > 0 && opponentArenaPieces.All(p => p == null))
+        {
+            EndArena(ArenaResult.PlayerWon);
+            return;
+        }
+
+        // AI 턴이 시작됐다는 것은 플레이어가 한 수를 뒀다는 의미
+        // — IsPlayerTurn이 false이면 방금 플레이어 반턴이 끝난 것
+        if (!GameManager.Instance.IsPlayerTurn)
+        {
+            playerMoveCount++;
+            if (playerMoveCount >= 8)
+                EndArena(ArenaResult.Timeout);
+        }
+    }
+
+    /// <summary>
+    /// 투기장을 종료하고 결과를 처리합니다.
+    /// </summary>
+    /// <param name="result">투기장 종료 원인</param>
+    public void EndArena(ArenaResult result)
+    {
+        if (!isArenaActive) return;
+        isArenaActive = false;
+
+        GameManager gm = GameManager.Instance;
+
+        // 이벤트 구독 해제 및 투기장 모드 비활성화
+        gm.OnHalfTurnChanged -= OnHalfTurnChanged;
+        gm.IsArenaMode = false;
+        gm.SetLockedPiece(null);
+
+        // King 무적 해제 — 메인 게임 복귀 후 King이 정상적으로 포획될 수 있어야 함
+        playerKing?.ConsumeInvincibility();
+        opponentKing?.ConsumeInvincibility();
+
+        // Timeout: 아레나 중 이동한 기물을 아레나 전 위치로 먼저 복원
+        // — BatchReassign은 2페이즈로 동작해 겹침 없이 다수 기물을 재배치함
+        // — 활성 기물을 원위치로 돌린 뒤 숨긴 기물을 복원해야 위치 충돌이 없음
+        if (result == ArenaResult.Timeout)
+        {
+            var piecesToRestore = new List<Piece>();
+            var originalPositions = new List<Vector3Int>();
+            foreach (var kv in savedPositions)
+            {
+                Piece p = kv.Key;
+                if (p != null && p.gameObject.activeSelf)
+                {
+                    piecesToRestore.Add(p);
+                    originalPositions.Add(kv.Value);
+                }
+            }
+            BoardManager.Instance.BatchReassign(piecesToRestore, originalPositions);
+            // BatchReassign이 King/Rook 이동 시 캐슬링 플래그를 false로 설정하므로 원래 권한으로 복원
+            BoardManager.Instance.SetCastlingFromFEN(savedCastlingFen);
+        }
+
+        // 숨겨두었던 비투기장 기물을 원래 위치에 복원
+        foreach (Piece p in hiddenPieces)
+            if (p != null) BoardManager.Instance.RestorePiece(p);
+        hiddenPieces.Clear();
+
+        switch (result)
+        {
+            case ArenaResult.PlayerWon:
+                // 상대 투기장 기물은 이미 DestroyPiece()로 제거된 상태이므로 추가 처리 불필요
+                Debug.Log("[Arena] 플레이어 승리 — 상대 투기장 기물 제거됨");
+                gm.SyncPositionToStockfish();
+                // RequestAIMove는 MoveSelected()가 NextTurn() 완료 후 호출 — 여기서 호출 시 GetLegalMoves와 충돌
+                break;
+
+            case ArenaResult.Timeout:
+                Debug.Log("[Arena] 8턴 초과 — 무효, 메인 게임 재개");
+                gm.SyncPositionToStockfish();
+                // RequestAIMove는 MoveSelected()가 NextTurn() 완료 후 호출 — 여기서 호출 시 GetLegalMoves와 충돌
+                break;
+
+            case ArenaResult.OpponentCheckmated:
+                Debug.Log("[Arena] 투기장 내 체크메이트 — 플레이어 게임 승리");
+                gm.OnSurrender(gm.EnemyColor);
+                break;
+        }
+    }
+}

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs.meta
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9c348ec35ec64034fb16e3079b555922

--- a/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fd1d52bc7835dc49a6852a596f9c1f0, type: 3}
+  m_Name: ArenaCard
+  m_EditorClassIdentifier: 
+  CardName: "\uD22C\uAE30\uC7A5"
+  CardImage: {fileID: 0}
+  CardDescription: "\uAE30\uBB3C\uC744 \uC120\uD0DD\uD558\uBA74 \uADF8 \uAE30\uBB3C(\uC2DC\uC804\uC790)\uACFC
+    \uB79C\uB364\uD55C \uC0C1\uB300 \uAE30\uBB3C 3\uAC1C\uB97C \uD22C\uAE30\uC7A5\uC73C\uB85C
+    \uC774\uB3D9\uD569\uB2C8\uB2E4."
+  Type: 2
+  CardTier: 0
+  PieceType: -1
+  PieceTargetColor: 0
+  PieceLimitTurn: 8
+  RequiredPieceCount: 1
+  TileCount: 0
+  MaintainTurn: 0
+  RestrictTiles: 0
+  BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  NeedTargetColor: 0
+  GlobalTargetColor: 0
+  HasLimit: 0
+  LimitTurn: 0
+  NeedAdditionalDescription: 0
+  DescriptionType: 0

--- a/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset.meta
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5386cf88badf52e4285efc816faebdc5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
@@ -2,28 +2,28 @@
 using UnityEngine;
 
 /// <summary>
-/// 투기장 - 타일 전용 (투기장)
-/// 지정된 구역에 랜덤한 기물이 배치되며, 해당 구역에서 기물들이 전투를 벌입니다.
+/// 투기장
+/// 랜덤한 상대 기물 3개와 플레이어 전체 기물이 투기장으로 이동합니다.
+/// 상대 기물이 모두 잡혔을 경우 잡힌 기물만 사라집니다.
+/// 최대 8턴 내에 처리하지 못하면 무효 처리됩니다.
 /// </summary>
-public class ArenaCard : CardData, ITileCard
+public class ArenaCard : CardData, ICard
 {
-    private TileSelector selector;
-
-    private void Awake()
-    {
-        selector = FindFirstObjectByType<TileSelector>();
-    }
-
-    public void LoadTileSelector()
-    {
-        if (selector == null) selector = FindFirstObjectByType<TileSelector>();
-        selector.EnableSelector(this);
-    }
-
     public void Execute(CardEffectArgs args = null)
     {
-        List<Vector3Int> tiles = args.TargetPos;
-        // TODO: 선택된 칸에 투기장 효과 적용
-        //       해당 구역에 랜덤한 기물 배치 및 투기장 카메라 활성화 처리
+        // 상대 King 제외 기물 중 랜덤 3개 선택
+        List<Piece> opponents = BoardManager.Instance.GetAllPieces()
+            .FindAll(p => p.Color == GameManager.Instance.EnemyColor
+                       && p.Type != PieceType.King);
+
+        // Fisher-Yates shuffle
+        for (int i = opponents.Count - 1; i > 0; i--)
+        {
+            int j = Random.Range(0, i + 1);
+            (opponents[i], opponents[j]) = (opponents[j], opponents[i]);
+        }
+
+        List<Piece> arenaOpponents = opponents.GetRange(0, Mathf.Min(3, opponents.Count));
+        ArenaManager.Instance.StartArena(arenaOpponents);
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -477,7 +477,28 @@ public class BoardManager : MonoBehaviour
         RefreshMoves();
     }
 
-    ///<summary> UCI 좌표를 Vector3Int로 바꿉니다 </summary> 
+    /// <summary>기물을 보드 배열과 리스트에서 제거합니다. GameObject는 유지됩니다.</summary>
+    public void HidePiece(Piece piece)
+    {
+        if (piece == null) return;
+        board[piece.Pos.x, piece.Pos.y] = null;
+        Pieces.Remove(piece);
+        piece.gameObject.SetActive(false);
+    }
+
+    /// <summary>HidePiece로 숨긴 기물을 원래 위치(piece.Pos)에 복원합니다.</summary>
+    public void RestorePiece(Piece piece)
+    {
+        if (piece == null) return;
+        board[piece.Pos.x, piece.Pos.y] = piece;
+        if (!Pieces.Contains(piece)) Pieces.Add(piece);
+        piece.gameObject.SetActive(true);
+    }
+
+    /// <summary>캐슬링 상태를 FEN 문자열로 복원합니다. 투기장 Timeout 복원에 사용됩니다.</summary>
+    public void SetCastlingFromFEN(string castlingFen) => castling.SetFen(castlingFen);
+
+    ///<summary> UCI 좌표를 Vector3Int로 바꿉니다 </summary>
     public Vector3Int UCIToGrid(string sq)
     {
         int x = sq[0] - 'a'; // 'a'~'h' → 0~7

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -16,6 +16,7 @@ public class GameManager : MonoBehaviour
     public bool IsPlayerTurn => (curTurn % 2 == 1);
 
     public bool IsGameInput = true;
+    public bool IsArenaMode { get; set; } = false;
     private List<(int turn, Action action)> recievedActions = new List<(int, Action)>();
 
     /// <summary>플레이어 턴이 시작되고 CanMovePos가 유효해진 직후 발행됩니다.</summary>
@@ -109,6 +110,9 @@ public class GameManager : MonoBehaviour
             boardUI.DeleteSelectTile();
         }
     }
+
+    /// <summary>lockedPiece를 설정합니다. 투기장 등 외부에서 기물 잠금이 필요할 때 사용합니다.</summary>
+    public void SetLockedPiece(Piece piece) => lockedPiece = piece;
 
     /// <summary>현재 플레이어에게 추가 행동권을 부여합니다. piece가 지정되면 해당 기물만 움직일 수 있습니다.</summary>
     public void GrantExtraPlayerAction(Piece piece = null)
@@ -222,11 +226,23 @@ public class GameManager : MonoBehaviour
             }
             else
             {
-                lockedPiece = null;
+                if (!IsArenaMode) lockedPiece = null;
                 NextTurn();
+                // EndArena(Timeout/PlayerWon)는 NextTurn 내부 OnHalfTurnChanged에서 SyncPositionToStockfish만 수행.
+                // RequestAIMove는 NextTurn()이 완전히 끝난 뒤 여기서 호출해 GetLegalMoves와의 충돌을 방지.
                 RequestAIMove();
             }
         }
+    }
+
+    /// <summary>현재 보드 상태를 Stockfish에 동기화합니다. 투기장 종료 후 기물 복원 시 사용합니다.</summary>
+    public void SyncPositionToStockfish()
+    {
+        BoardManager.Instance.UpdateFEN();
+        string fen = BoardManager.Instance.GetFEN();
+        FairyStockfishBridge.Instance.SetPosition(fen);
+        string[] moves = FairyStockfishBridge.Instance.GetLegalMoves();
+        BoardManager.Instance.UpdatePiecesCanMovePos(moves);
     }
 
     public void RequestAIMove()
@@ -243,6 +259,13 @@ public class GameManager : MonoBehaviour
     }
     private void EvaluateGameState(string[] moves)
     {
+        if (IsArenaMode)
+        {
+            // 투기장 중 체크메이트는 아레나 정리 후 처리 (OnCheckmate 직접 호출 시 RequestAIMove와 경합)
+            if (moves.Length == 0 && FairyStockfishBridge.Instance.IsInCheck())
+                ArenaManager.Instance.EndArena(ArenaResult.OpponentCheckmated);
+            return;
+        }
         if (BoardManager.Instance.GetHalfmoveClock() >= 150)
         {
             OnDraw();

--- a/ChaosChess_v2/ChaosChess_v2.slnx
+++ b/ChaosChess_v2/ChaosChess_v2.slnx
@@ -1,5 +1,0 @@
-﻿<Solution>
-  <Project Path="Assembly-CSharp.csproj" />
-  <Project Path="Assembly-CSharp-firstpass.csproj" />
-  <Project Path="Assembly-CSharp-Editor.csproj" />
-</Solution>


### PR DESCRIPTION
## 개요

투기장 스킬 카드를 구현합니다.
카드를 사용하면 플레이어 전체 기물 vs 랜덤 상대 기물 3개의 미니 배틀이 시작됩니다.
최대 8턴 안에 결과가 결정되며, 이후 메인 게임으로 복귀합니다.

---

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `Script/Arena/ArenaManager.cs` | 신규 — 투기장 생명주기 관리 싱글턴 |
| `Script/Card/skills/ArenaCard.cs` | 투기장 카드 구현 (`ICard`) |
| `Script/ChessSystem/GameManager.cs` | `IsArenaMode`, `SyncPositionToStockfish()`, `EvaluateGameState` 아레나 분기, `MoveSelected` 타이밍 수정 |
| `Script/ChessSystem/BoardManager.cs` | `HidePiece`, `RestorePiece`, `SetCastlingFromFEN` 추가 |
| `Script/Card/SO/ArenaCard.asset` | 카드 ScriptableObject |

---

## 동작 방식

```
StartArena()
  ├── 플레이어 전체 기물 + 상대 3개 + 상대 King 유지
  ├── 나머지 기물 HidePiece() (보드 배열 제거 + SetActive false)
  ├── 양쪽 King SetInvincible() (Stockfish FEN 호환용)
  └── 아레나 시작 시점 위치 + 캐슬링 권한 스냅샷 저장

OnHalfTurnChanged()  매 반턴 호출
  ├── King 무적 갱신
  ├── 상대 기물 전멸 → PlayerWon
  └── 8 플레이어 턴 초과 → Timeout

EndArena()
  ├── [Timeout] BatchReassign으로 모든 기물 원위치 복원
  │            + SetCastlingFromFEN으로 캐슬링 권한 복원
  ├── RestorePiece()로 숨긴 기물 복원
  ├── SyncPositionToStockfish()로 올바른 FEN 전달
  └── RequestAIMove()는 MoveSelected()가 NextTurn() 완료 후 호출
```

---

## 종료 조건

| 결과 | 내용 |
|------|------|
| `PlayerWon` | 상대 3개 기물 전멸 → 포획된 기물만 영구 제거, 게임 재개 |
| `Timeout` | 8턴 초과 → 모든 기물 원위치 복원, 게임 재개 |
| `OpponentCheckmated` | 아레나 내 체크메이트 → 플레이어 게임 승리 |

---

## 버그 수정

- **Stockfish freeze**: `RequestAIMove()`를 `NextTurn()` 내부(`OnHalfTurnChanged`)가 아닌 완료 후에 호출하도록 변경 — `GetLegalMoves()`와의 충돌 방지
- **기물 위치 겹침**: Timeout 시 `BatchReassign()`으로 아레나 중 이동한 기물을 먼저 원위치시킨 뒤 숨긴 기물 복원
- **캐슬링 권한 손실**: `BatchReassign()`이 King/Rook 이동 시 캐슬링 플래그를 초기화하는 문제 → 아레나 시작 시점의 캐슬링 FEN을 저장 후 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)