### PR TITLE
[Fix] 턴 넘기는 카드들이 메인 스레드를 점유하는 문제 해결

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -333,6 +333,108 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7606164}
   m_CullTransparentMesh: 1
+--- !u!1001 &7953734
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 232779361}
+    m_Modifications:
+    - target: {fileID: 5226435468396453821, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_Name
+      value: ReviveCard
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 436
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 581.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+--- !u!224 &7953735 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9062307038781313807, guid: 37f936baf5d7e0a45aa4d3ea9a73663d, type: 3}
+  m_PrefabInstance: {fileID: 7953734}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &14408961
 GameObject:
   m_ObjectHideFlags: 0
@@ -1262,8 +1364,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1778810404}
-  - {fileID: 1249377877}
+  - {fileID: 1707578116}
+  - {fileID: 7953735}
+  - {fileID: 503069869}
+  - {fileID: 978732812}
   m_Father: {fileID: 1036672678}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2295,7 +2399,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 475878337}
   m_CullTransparentMesh: 1
---- !u!1001 &488534680
+--- !u!1001 &503069868
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -2303,95 +2407,100 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 232779361}
     m_Modifications:
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 6352077095358507004, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
+      propertyPath: m_Name
+      value: OverbearingCard
+      objectReference: {fileID: 0}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_SizeDelta.x
       value: 436
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_SizeDelta.y
       value: 581.3
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+    - target: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3813447576285901271, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
-      propertyPath: m_Name
-      value: BlessingCard
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
+--- !u!224 &503069869 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7884909132316011342, guid: 7de6ba864f2d30b41b9b190af97fb463, type: 3}
+  m_PrefabInstance: {fileID: 503069868}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &507959201
 GameObject:
   m_ObjectHideFlags: 0
@@ -4481,6 +4590,108 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1309221203}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &978732811
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 232779361}
+    m_Modifications:
+    - target: {fileID: 5674481883444440734, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_Name
+      value: TeleportCard
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 436
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 581.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+--- !u!224 &978732812 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8931764337199587884, guid: d76a076c77e429b4bbf570e34d75c3c0, type: 3}
+  m_PrefabInstance: {fileID: 978732811}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1007872085
 GameObject:
   m_ObjectHideFlags: 0
@@ -6752,103 +6963,6 @@ MonoBehaviour:
   isStartAnimation: 0
   isEndAnimation: 0
   nextSceneName: 
---- !u!1001 &1182135229
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 232779361}
-    m_Modifications:
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 436
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 581.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7634445145627062371, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-      propertyPath: m_Name
-      value: FireCard
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
 --- !u!1 &1190515892
 GameObject:
   m_ObjectHideFlags: 0
@@ -7497,11 +7611,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!224 &1249377877 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6681424350163156177, guid: 59fda4040feb71549a7b1e33e6dac203, type: 3}
-  m_PrefabInstance: {fileID: 1182135229}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1261601846
 GameObject:
   m_ObjectHideFlags: 0
@@ -9631,11 +9740,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!224 &1612019082 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 119302781655367013, guid: 7514f4f302e77c4499f2bae34e86660d, type: 3}
-  m_PrefabInstance: {fileID: 488534680}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1624611053
 GameObject:
   m_ObjectHideFlags: 0
@@ -10281,6 +10385,108 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1696706057}
   m_CullTransparentMesh: 1
+--- !u!1001 &1707578115
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 232779361}
+    m_Modifications:
+    - target: {fileID: 488242485071545191, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_Name
+      value: WeirdCastling
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 436
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 581.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+--- !u!224 &1707578116 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3714724871257804757, guid: 0cdb9f69432c82549ae2f1314219c7df, type: 3}
+  m_PrefabInstance: {fileID: 1707578115}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1723749301
 GameObject:
   m_ObjectHideFlags: 0
@@ -10782,108 +10988,6 @@ MonoBehaviour:
   isStartAnimation: 0
   isEndAnimation: 0
   nextSceneName: 
---- !u!1001 &1778810403
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 232779361}
-    m_Modifications:
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 436
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 581.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9098737615895007944, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-      propertyPath: m_Name
-      value: TimeBombCard
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
---- !u!224 &1778810404 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5408535927619903098, guid: 11ab009e147778a408206a5414ae3b76, type: 3}
-  m_PrefabInstance: {fileID: 1778810403}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1784817159
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Card/Skills/OverbearingCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/OverbearingCard.cs
@@ -19,7 +19,7 @@ public class OverbearingEffector : GlobalEffector
     protected override void OnApply()
     {
         List<Piece> pieces = BoardManager.Instance.GetAllPieces();
-        foreach(Piece piece in pieces)
+        foreach (Piece piece in pieces)
         {
             Debug.Log(piece.Type);
             if (piece.Color == GameManager.Instance.turnColor)
@@ -35,9 +35,8 @@ public class OverbearingEffector : GlobalEffector
             }
         }
         BoardManager.Instance.RefreshMoves();
-        GameManager.Instance.NextTurn();
-        if (!GameManager.Instance.IsPlayerTurn)
-            GameManager.Instance.RequestAIMove();
+        GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
+
         Revert();
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/Skills/ReviveCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/ReviveCard.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using System.Collections.Generic;
 /// <summary>
-/// ºÎÈ° - Å¸ÀÏ Àü¿ë (·¹¾î)
-/// ¼±ÅÃÇÑ Å¸ÀÏ¿¡¼­ Á×Àº ±â¹° Áß °¡Àå °¡Ä¡°¡ ³ôÀº ±â¹°ÀÌ ºÎÈ°ÇÕ´Ï´Ù
+/// ï¿½ï¿½È° - Å¸ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ (ï¿½ï¿½ï¿½ï¿½)
+/// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Å¸ï¿½Ï¿ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½â¹° ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ä¡ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½â¹°ï¿½ï¿½ ï¿½ï¿½È°ï¿½Õ´Ï´ï¿½
 /// </summary>
 public class ReviveCard : CardData, ITileCard
 {
@@ -73,7 +73,7 @@ public class ReviveEffector : TileEffector
         PieceType res = PieceType.Wall;
         if (pieces != null)
         {
-            foreach(PieceType piece in pieces)
+            foreach (PieceType piece in pieces)
             {
                 int g = (int)GetValue(piece);
                 if (g > maxv)
@@ -84,11 +84,9 @@ public class ReviveEffector : TileEffector
             }
         }
         pieces.Remove(res);
-        BoardManager.Instance.ChangePiece(TilePos, GameManager.Instance.turnColor,TypeToChar(res));
+        BoardManager.Instance.ChangePiece(TilePos, GameManager.Instance.turnColor, TypeToChar(res));
         Revert();
-        GameManager.Instance.NextTurn();
-        if (!GameManager.Instance.IsPlayerTurn)
-            GameManager.Instance.RequestAIMove();
+        GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
     }
 
     protected override void OnRevert()

--- a/ChaosChess_v2/Assets/Script/Card/skills/FatherEnemyCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/FatherEnemyCard.cs
@@ -56,10 +56,7 @@ public class FatherEnemyEffector : PieceEffector
     {
         GameManager.Instance.OnAwakenedPieceSelected -= OnPieceSelected;
 
-        GameManager.Instance.NextTurn();
-
-        if (!GameManager.Instance.IsPlayerTurn)
-            GameManager.Instance.RequestAIMove();
+        GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
 
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
@@ -20,9 +20,7 @@ public class PositionSwapCard : CardData, ICard
         bm.ClearAllTileEffectors();
         bm.RefreshMoves();
 
-        GameManager.Instance.NextTurn();
-        if (!GameManager.Instance.IsPlayerTurn)
-            GameManager.Instance.RequestAIMove();
+        GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
     }
 
     private string FlipFEN(string fen)

--- a/ChaosChess_v2/Assets/Script/Card/skills/TeleportCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/TeleportCard.cs
@@ -42,7 +42,6 @@ public class TeleportCard : CardData, IPieceCard, ITileCard
         Vector3Int target = args.TargetPos[0];
 
         BoardManager.Instance.ForceTeleport(pawn, target, '\0', true);
-        GameManager.Instance.RequestAIMove();
     }
 
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/WeirdCastling.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/WeirdCastling.cs
@@ -32,8 +32,6 @@ public class WeirdCastling : CardData, IPieceCard
         List<Vector3Int> newPositions = new List<Vector3Int> { targetPiece.Pos, king.Pos };
         BoardManager.Instance.BatchReassign(pieces, newPositions);
 
-        GameManager.Instance.NextTurn();
-        if (!GameManager.Instance.IsPlayerTurn)
-            GameManager.Instance.RequestAIMove();
+        GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -806,7 +806,7 @@ public class BoardManager : MonoBehaviour
         {
             if (useTurn)
             {
-                GameManager.Instance.NextTurn();
+                GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
             }
             else
             {

--- a/ChaosChess_v2/ChaosChess_v2.slnx
+++ b/ChaosChess_v2/ChaosChess_v2.slnx
@@ -1,0 +1,5 @@
+﻿<Solution>
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-firstpass.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
+</Solution>


### PR DESCRIPTION
# 개요
턴 넘기는 카드들이 메인 스레드를 점유하는 문제를 해결했습니다.

## 설명
```cs
 GameManager.Instance.NextTurn();
 if (!GameManager.Instance.IsPlayerTurn)
    GameManager.Instance.RequestAIMove();
```
이렇게 된 코드를 
```cs
GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
```
이렇게 수정했습니다.