### PR TITLE
[Feature] 투기장 효과 저장 기능 구현 (재 pr)

### DIFF
--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -222,13 +222,11 @@ public class ArenaManager : MonoBehaviour
     private void SuspendStoredEffects()
     {
         suspendedEffects.Clear();
+        BoardManager bm = BoardManager.Instance;
 
-        foreach (Effector effector in FindObjectsByType<Effector>(FindObjectsSortMode.None))
+        foreach (GlobalEffector effector in bm.GetGlobalEffectors())
         {
             if (effector == null || effector.IsSuspended)
-                continue;
-            // 요청사항: 기물 효과는 유지하고, 타일/전역 효과만 일시 정지
-            if (effector is not TileEffector && effector is not GlobalEffector)
                 continue;
             // 카드 특성상 투기장에서도 유지돼야 하는 효과는 제외
             if (effector is IArenaPersistentEffect)
@@ -238,7 +236,19 @@ public class ArenaManager : MonoBehaviour
             effector.SuspendForArena();
         }
 
-        BoardManager.Instance.RefreshMoves();
+        foreach (TileEffector effector in bm.GetAllTileEffectors())
+        {
+            if (effector == null || effector.IsSuspended)
+                continue;
+            // 카드 특성상 투기장에서도 유지돼야 하는 효과는 제외
+            if (effector is IArenaPersistentEffect)
+                continue;
+
+            suspendedEffects.Add(effector);
+            effector.SuspendForArena();
+        }
+
+        bm.RefreshMoves();
     }
 
     /// <summary>투기장 전에 저장해 둔 타일/전역 효과를 다시 활성화합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.Tilemaps;
 
 public enum ArenaResult { PlayerWon, Timeout, OpponentCheckmated }
 
@@ -24,6 +25,8 @@ public enum ArenaResult { PlayerWon, Timeout, OpponentCheckmated }
 public class ArenaManager : MonoBehaviour
 {
     public static ArenaManager Instance;
+    /// <summary>투기장 시작 전 저장된(일시정지된) 타일/전역 효과가 존재하는지 여부입니다.</summary>
+    public bool AreStoredEffectsSuspended => isArenaActive && suspendedEffects.Count > 0;
 
     // 투기장 참가 기물
     private List<Piece> opponentArenaPieces = new();  // 상대 투기장 기물 (최대 3개)
@@ -41,6 +44,10 @@ public class ArenaManager : MonoBehaviour
     // Timeout 복원용: 아레나 시작 시점의 모든 기물 위치 스냅샷
     private Dictionary<Piece, Vector3Int> savedPositions = new();
     private string savedCastlingFen;  // 아레나 시작 시점의 캐슬링 권한 (Timeout 시 복원)
+    // 투기장 진입 전 잠시 꺼두는 효과 목록(타일/전역만)
+    private readonly List<Effector> suspendedEffects = new();
+    // 타일 이펙트(시각 효과) 복원용 스냅샷
+    private Dictionary<Vector3Int, TileBase> savedTileEffects = new();
 
     private void Awake()
     {
@@ -73,6 +80,10 @@ public class ArenaManager : MonoBehaviour
         // 캐슬링 권한 저장 — BatchReassign이 King/Rook 복원 시 플래그를 손상시키므로 별도 보존
         bm.UpdateFEN();
         savedCastlingFen = bm.GetFEN().Split(' ')[2];
+        savedTileEffects = bm.TileEffectDrawer.CaptureTileEffects();
+        SuspendStoredEffects();
+        gm.PauseQueuedActions();
+        bm.TileEffectDrawer.ClearAllTileEffects();
 
         // 양쪽 King 참조 저장 — Stockfish 연산에 필요
         playerKing = allPiece.Find(p => p.Color == gm.PlayerColor && p.Type == PieceType.King);
@@ -181,6 +192,9 @@ public class ArenaManager : MonoBehaviour
         foreach (Piece p in hiddenPieces)
             if (p != null) BoardManager.Instance.RestorePiece(p);
         hiddenPieces.Clear();
+        ResumeStoredEffects();
+        BoardManager.Instance.TileEffectDrawer.RestoreTileEffects(savedTileEffects);
+        gm.ResumeQueuedActions();
 
         switch (result)
         {
@@ -202,5 +216,43 @@ public class ArenaManager : MonoBehaviour
                 gm.OnSurrender(gm.EnemyColor);
                 break;
         }
+    }
+
+    /// <summary>투기장 시작 전 타일/전역 효과를 저장 목록에 넣고 일시 정지합니다.</summary>
+    private void SuspendStoredEffects()
+    {
+        suspendedEffects.Clear();
+
+        foreach (Effector effector in FindObjectsByType<Effector>(FindObjectsSortMode.None))
+        {
+            if (effector == null || effector.IsSuspended)
+                continue;
+            // 요청사항: 기물 효과는 유지하고, 타일/전역 효과만 일시 정지
+            if (effector is not TileEffector && effector is not GlobalEffector)
+                continue;
+            // 카드 특성상 투기장에서도 유지돼야 하는 효과는 제외
+            if (effector is IArenaPersistentEffect)
+                continue;
+
+            suspendedEffects.Add(effector);
+            effector.SuspendForArena();
+        }
+
+        BoardManager.Instance.RefreshMoves();
+    }
+
+    /// <summary>투기장 전에 저장해 둔 타일/전역 효과를 다시 활성화합니다.</summary>
+    private void ResumeStoredEffects()
+    {
+        foreach (Effector effector in suspendedEffects.ToList())
+        {
+            if (effector == null)
+                continue;
+
+            effector.ResumeFromArena();
+        }
+
+        suspendedEffects.Clear();
+        BoardManager.Instance.RefreshMoves();
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/CardData.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardData.cs
@@ -19,6 +19,7 @@ public abstract class CardData : MonoBehaviour
         GameObject host = new GameObject($"TileEffect_{pos}");
         T effector = host.AddComponent<T>();
         effector.Init(pos, DataSO.MaintainTurn);
+        effector.CardSO = DataSO;
         return effector;
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Reflection;
 using UnityEngine;
 
 /// <summary>투기장 진입 시에도 일시정지하지 않고 유지할 효과 마커입니다.</summary>
@@ -107,9 +106,7 @@ public abstract class Effector : MonoBehaviour, IEffect
     /// <summary>효과 타입별(DataSO) 타일 연출을 끄거나 켭니다.</summary>
     private void ToggleTileVisual(bool enabled)
     {
-        CardDataSO dataSO = GetType()
-            .GetField("DataSO", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?.GetValue(this) as CardDataSO;
+        CardDataSO dataSO = VisualDataSO;
 
         if (dataSO == null || !dataSO.NeedEffectTileBase || dataSO.EffectTileBase == null)
             return;
@@ -123,20 +120,11 @@ public abstract class Effector : MonoBehaviour, IEffect
         }
     }
 
-    private IEnumerable<Vector3Int> GetVisualPositions()
-    {
-        var positions = new List<Vector3Int>();
-        var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+    /// <summary>타일 연출에 사용할 카드 데이터입니다. 필요 시 서브 클래스에서 재정의합니다.</summary>
+    protected virtual CardDataSO VisualDataSO => null;
 
-        foreach (string fieldName in new[] { "tilePos", "TilePos", "MinePos", "syncTilePos" })
-        {
-            FieldInfo field = GetType().GetField(fieldName, flags);
-            if (field?.FieldType == typeof(Vector3Int))
-                positions.Add((Vector3Int)field.GetValue(this));
-        }
-
-        return positions;
-    }
+    /// <summary>타일 연출에 사용할 좌표 목록입니다. 필요 시 서브 클래스에서 재정의합니다.</summary>
+    protected virtual IEnumerable<Vector3Int> GetVisualPositions() { yield break; }
 }
 
 /// <summary>기물에 부착되는 효과의 기반 추상 클래스</summary>
@@ -158,6 +146,8 @@ public abstract class PieceEffector : Effector, IPieceEffect
 /// <summary>타일에 부착되는 효과의 기반 추상 클래스</summary>
 public abstract class TileEffector : Effector, ITileEffect
 {
+    public CardDataSO CardSO { get; set; }
+
     public Vector3Int TilePos
     {
         get
@@ -185,6 +175,13 @@ public abstract class TileEffector : Effector, ITileEffect
     protected override void OnResumeFromArena()
     {
         BoardManager.Instance?.RegisterTileEffector(tilePos, this);
+    }
+
+    protected override CardDataSO VisualDataSO => CardSO;
+
+    protected override IEnumerable<Vector3Int> GetVisualPositions()
+    {
+        yield return tilePos;
     }
 }
 
@@ -247,4 +244,6 @@ public abstract class GlobalEffector : Effector
     {
         BoardManager.Instance?.RegisterGlobalEffector(this);
     }
+
+    protected override CardDataSO VisualDataSO => CardSO;
 }

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -1,14 +1,22 @@
-﻿using UnityEngine;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+/// <summary>투기장 진입 시에도 일시정지하지 않고 유지할 효과 마커입니다.</summary>
+public interface IArenaPersistentEffect { }
 
 /// <summary>기물 또는 타일에 효과를 적용하고 관리하는 추상 컴포넌트</summary>
 public abstract class Effector : MonoBehaviour, IEffect
 {
     private int remainingTurns; // -1 = 영구 효과
     private bool useHalfTurn; // 반턴 사용 여부
+    // 투기장 등 특수 모드에서 효과 동작을 잠시 멈출 때 사용합니다.
+    private bool isSuspended;
 
     public bool IsExpired => remainingTurns == 0;
     public bool IsPermanent => remainingTurns < 0;
     public int RemainingTurns => remainingTurns;
+    public bool IsSuspended => isSuspended;
 
     protected void SetDuration(int turns)
     {
@@ -39,6 +47,39 @@ public abstract class Effector : MonoBehaviour, IEffect
         OnEffectReverted();
     }
 
+    /// <summary>투기장 동안 효과를 일시 정지합니다.</summary>
+    public void SuspendForArena()
+    {
+        if (isSuspended) return;
+
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnTurnChanged -= OnTurnChanged;
+            if (useHalfTurn)
+                GameManager.Instance.OnHalfTurnChanged -= OnHalfTurnChanged;
+        }
+
+        isSuspended = true;
+        ToggleTileVisual(false);
+        OnSuspendForArena();
+    }
+
+    /// <summary>투기장 종료 후 효과를 재개합니다.</summary>
+    public void ResumeFromArena()
+    {
+        if (!isSuspended) return;
+
+        isSuspended = false;
+        ToggleTileVisual(true);
+        OnResumeFromArena();
+
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.OnTurnChanged += OnTurnChanged;
+            if (useHalfTurn)
+                GameManager.Instance.OnHalfTurnChanged += OnHalfTurnChanged;
+        }
+    }
 
     /// <summary>서브클래스에서 훅/버프를 부착합니다.</summary>
     protected abstract void OnApply();
@@ -48,6 +89,9 @@ public abstract class Effector : MonoBehaviour, IEffect
 
     protected virtual void OnEffectApplied() { }
     protected virtual void OnEffectReverted() { }
+
+    protected virtual void OnSuspendForArena() { }
+    protected virtual void OnResumeFromArena() { }
 
     public virtual void OnTurnChanged()
     {
@@ -59,6 +103,40 @@ public abstract class Effector : MonoBehaviour, IEffect
     }
 
     protected virtual void OnHalfTurnChanged() { }
+
+    /// <summary>효과 타입별(DataSO) 타일 연출을 끄거나 켭니다.</summary>
+    private void ToggleTileVisual(bool enabled)
+    {
+        CardDataSO dataSO = GetType()
+            .GetField("DataSO", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(this) as CardDataSO;
+
+        if (dataSO == null || !dataSO.NeedEffectTileBase || dataSO.EffectTileBase == null)
+            return;
+
+        foreach (Vector3Int pos in GetVisualPositions())
+        {
+            if (enabled)
+                BoardManager.Instance?.TileEffectDrawer?.SetTileEffect(pos, dataSO.EffectTileBase);
+            else
+                BoardManager.Instance?.TileEffectDrawer?.ClearTileEffect(pos);
+        }
+    }
+
+    private IEnumerable<Vector3Int> GetVisualPositions()
+    {
+        var positions = new List<Vector3Int>();
+        var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        foreach (string fieldName in new[] { "tilePos", "TilePos", "MinePos", "syncTilePos" })
+        {
+            FieldInfo field = GetType().GetField(fieldName, flags);
+            if (field?.FieldType == typeof(Vector3Int))
+                positions.Add((Vector3Int)field.GetValue(this));
+        }
+
+        return positions;
+    }
 }
 
 /// <summary>기물에 부착되는 효과의 기반 추상 클래스</summary>
@@ -98,6 +176,16 @@ public abstract class TileEffector : Effector, ITileEffect
     public virtual void OnPieceEnter(Piece piece) { }
     public virtual void OnPieceExit(Piece piece) { }
     public virtual bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to) { return true; }
+
+    protected override void OnSuspendForArena()
+    {
+        BoardManager.Instance?.UnregisterTileEffector(tilePos, this);
+    }
+
+    protected override void OnResumeFromArena()
+    {
+        BoardManager.Instance?.RegisterTileEffector(tilePos, this);
+    }
 }
 
 /// <summary>특정 타입의 기물이 행동(이동/잡기)했을 때 반응하는 전역 효과의 기반 추상 클래스</summary>
@@ -149,4 +237,14 @@ public abstract class GlobalEffector : Effector
     }
 
     public virtual bool CanPieceAct(Piece piece, Vector3Int from, Vector3Int to) { return true; }
+
+    protected override void OnSuspendForArena()
+    {
+        BoardManager.Instance?.UnregisterGlobalEffector(this);
+    }
+
+    protected override void OnResumeFromArena()
+    {
+        BoardManager.Instance?.RegisterGlobalEffector(this);
+    }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -7,6 +7,8 @@ public class PieceSelector : Selector<Piece>
 {
     [SerializeField] private UIPieceDrawer pieceDrawer;
     [SerializeField] private SelectorUI selectorUI;
+    // GetComponents(List<T>) 재사용 버퍼로 선택 시점 GC 할당을 줄입니다.
+    private readonly List<PieceEffector> pieceEffectorBuffer = new();
     private IPieceCard skillCard;
     private bool executable => isExecute();
 
@@ -61,7 +63,7 @@ public class PieceSelector : Selector<Piece>
     {
         if (!selectState) return;
 
-        if (Target.GetComponents<PieceEffector>().Any(e => !e.IsSuspended))
+        if (HasActivePieceEffector(Target))
         {
             // 현재 활성(일시정지 아님) 기물 효과가 있으면 중복 적용을 막습니다.
             Target.NotSelect();
@@ -126,7 +128,7 @@ public class PieceSelector : Selector<Piece>
         foreach(Piece piece in pieces)
         {
             // 효과가 전혀 없거나, 전부 투기장 일시정지 상태이면 대상 가능으로 봅니다.
-            if (!piece.GetComponents<PieceEffector>().Any(e => !e.IsSuspended))
+            if (!HasActivePieceEffector(piece))
             {
                 return true;
             }
@@ -167,5 +169,18 @@ public class PieceSelector : Selector<Piece>
         selectedTargets.Clear();
         selectorUI.DisableButtonState();
 
+    }
+
+    /// <summary>해당 기물에 일시정지되지 않은 PieceEffector가 하나라도 있는지 확인합니다.</summary>
+    private bool HasActivePieceEffector(Piece piece)
+    {
+        pieceEffectorBuffer.Clear();
+        piece.GetComponents(pieceEffectorBuffer);
+        foreach (PieceEffector effector in pieceEffectorBuffer)
+        {
+            if (effector != null && !effector.IsSuspended)
+                return true;
+        }
+        return false;
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -61,8 +61,9 @@ public class PieceSelector : Selector<Piece>
     {
         if (!selectState) return;
 
-        if(Target.TryGetComponent<PieceEffector>(out var effector))
+        if (Target.GetComponents<PieceEffector>().Any(e => !e.IsSuspended))
         {
+            // 현재 활성(일시정지 아님) 기물 효과가 있으면 중복 적용을 막습니다.
             Target.NotSelect();
             return;
         }
@@ -124,7 +125,8 @@ public class PieceSelector : Selector<Piece>
         // 2. 기물 중 효과 적용 중인지 검사
         foreach(Piece piece in pieces)
         {
-            if(!piece.TryGetComponent<PieceEffector>(out var value))
+            // 효과가 전혀 없거나, 전부 투기장 일시정지 상태이면 대상 가능으로 봅니다.
+            if (!piece.GetComponents<PieceEffector>().Any(e => !e.IsSuspended))
             {
                 return true;
             }

--- a/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
+++ b/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using System.Collections.Generic;
 
 public class UITileEffectDrawer : MonoBehaviour
 {
@@ -13,5 +14,40 @@ public class UITileEffectDrawer : MonoBehaviour
     public void ClearTileEffect(Vector3Int pos)
     {
         effectTilemap.SetTile(pos, null);
+    }
+
+    /// <summary>현재 타일 이펙트 맵을 위치-타일 스냅샷으로 저장합니다.</summary>
+    public Dictionary<Vector3Int, TileBase> CaptureTileEffects()
+    {
+        var snapshot = new Dictionary<Vector3Int, TileBase>();
+
+        foreach (Vector3Int pos in effectTilemap.cellBounds.allPositionsWithin)
+        {
+            TileBase tile = effectTilemap.GetTile(pos);
+            if (tile != null)
+                snapshot[pos] = tile;
+        }
+
+        return snapshot;
+    }
+
+    /// <summary>저장된 스냅샷 기준으로 타일 이펙트를 복원합니다.</summary>
+    public void RestoreTileEffects(Dictionary<Vector3Int, TileBase> snapshot)
+    {
+        effectTilemap.ClearAllTiles();
+
+        if (snapshot == null)
+            return;
+
+        foreach (var pair in snapshot)
+        {
+            effectTilemap.SetTile(pair.Key, pair.Value);
+        }
+    }
+
+    /// <summary>타일 이펙트 맵을 전체 초기화합니다.</summary>
+    public void ClearAllTileEffects()
+    {
+        effectTilemap.ClearAllTiles();
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -49,7 +50,7 @@ public class ATMineEffector : GlobalEffector
         // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.SetTileEffect(MinePos, DataSO.EffectTileBase);
-            
+
         BoardManager.Instance.RegisterGlobalEffector(this);
     }
 
@@ -144,5 +145,10 @@ public class ATMineEffector : GlobalEffector
             BoardManager.Instance.RefreshMoves();
 
         Revert();
+    }
+
+    protected override IEnumerable<Vector3Int> GetVisualPositions()
+    {
+        yield return MinePos;
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
 /// 거미줄 - 타일전용
@@ -135,6 +136,11 @@ public class CobwebEffector : GlobalEffector
         }
 
         return Vector3Int.zero;
+    }
+
+    protected override IEnumerable<Vector3Int> GetVisualPositions()
+    {
+        yield return TilePos;
     }
 }
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
@@ -111,9 +111,10 @@ public class LimitlessFieldController
         if (pieceEff != null)
             pieceEff.Revert();
     }
+
 }
 
-public class LimitlessTileEffector : TileEffector
+public class LimitlessTileEffector : TileEffector, IArenaPersistentEffect
 {
     private LimitlessFieldController controller;
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
@@ -10,11 +10,11 @@ public class WindmillCard : CardData, ICard
     public void Execute(CardEffectArgs args = null)
     {
         var effector = CreateGlobalEffector<WindmillEffector>();
-        foreach(Piece piece in BoardManager.Instance.GetAllPieces())
+        foreach (Piece piece in BoardManager.Instance.GetAllPieces())
         {
             piece.MoveFenOverride = piece.Type == PieceType.Rook ? "b" : piece.Type == PieceType.Bishop ? "r" : null;
-            GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, effector.Revert);
         }
+        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, effector.Revert);
         effector.Apply();
 
     }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using DG.Tweening;
 
@@ -419,7 +418,7 @@ public class BoardManager : MonoBehaviour
         TriggerGlobalEffectors(piece, target, isCapture);
         TriggerTileEnter(target, piece);
 
-        foreach (var eff in piece.GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        foreach (var eff in piece.GetComponents<IPieceEffect>())
         {
             eff.OnPieceMove(target);
         }
@@ -489,7 +488,7 @@ public class BoardManager : MonoBehaviour
         if (piece == null) return;
 
         board[piece.Pos.x, piece.Pos.y] = null;
-        foreach (var eff in piece.GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        foreach (var eff in piece.GetComponents<IPieceEffect>())
         {
             eff.OnPieceCaptured();
         }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -702,6 +702,12 @@ public class BoardManager : MonoBehaviour
         globalEffectors.Add(effector);
     }
 
+    /// <summary>현재 등록된 전역 이펙터 목록의 스냅샷을 반환합니다.</summary>
+    public List<GlobalEffector> GetGlobalEffectors()
+    {
+        return new List<GlobalEffector>(globalEffectors);
+    }
+
     public void UnregisterGlobalEffector(GlobalEffector effector)
     {
         globalEffectors.Remove(effector);
@@ -749,6 +755,21 @@ public class BoardManager : MonoBehaviour
     {
         if (tileEffectors.TryGetValue(pos, out var list))
             list.Remove(effector);
+    }
+
+    /// <summary>현재 보드에 등록된 모든 타일 이펙터를 중복 없이 반환합니다.</summary>
+    public List<TileEffector> GetAllTileEffectors()
+    {
+        HashSet<TileEffector> result = new HashSet<TileEffector>();
+        foreach (var pair in tileEffectors)
+        {
+            foreach (TileEffector effector in pair.Value)
+            {
+                if (effector != null)
+                    result.Add(effector);
+            }
+        }
+        return new List<TileEffector>(result);
     }
 
     private void TriggerTileEnter(Vector3Int pos, Piece piece)

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DG.Tweening;
 
@@ -418,8 +419,10 @@ public class BoardManager : MonoBehaviour
         TriggerGlobalEffectors(piece, target, isCapture);
         TriggerTileEnter(target, piece);
 
-        foreach (var eff in piece.GetComponents<IPieceEffect>())
+        foreach (var eff in piece.GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        {
             eff.OnPieceMove(target);
+        }
 
         return true;
     }
@@ -486,7 +489,10 @@ public class BoardManager : MonoBehaviour
         if (piece == null) return;
 
         board[piece.Pos.x, piece.Pos.y] = null;
-        piece.GetComponent<IPieceEffect>()?.OnPieceCaptured();
+        foreach (var eff in piece.GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        {
+            eff.OnPieceCaptured();
+        }
         Pieces.Remove(piece);
         Destroy(piece.gameObject);
 
@@ -670,6 +676,10 @@ public class BoardManager : MonoBehaviour
     {
         foreach (var effector in globalEffectors)
         {
+            // 저장된(일시정지된) 전역 효과는 판정에서 제외합니다.
+            if (effector == null || effector.IsSuspended)
+                continue;
+
             if (!effector.CanPieceAct(piece, from, to))
                 return false;
         }
@@ -677,6 +687,10 @@ public class BoardManager : MonoBehaviour
         if (!tileEffectors.TryGetValue(to, out var list)) return true;
         foreach (var effector in list)
         {
+            // 저장된(일시정지된) 타일 효과는 판정에서 제외합니다.
+            if (effector == null || effector.IsSuspended)
+                continue;
+
             if (!effector.CanPieceEnter(piece, from, to))
                 return false;
         }
@@ -698,6 +712,10 @@ public class BoardManager : MonoBehaviour
     {
         foreach (var effector in new List<GlobalEffector>(globalEffectors))
         {
+            // 저장된(일시정지된) 전역 효과는 발동하지 않습니다.
+            if (effector == null || effector.IsSuspended)
+                continue;
+
             effector.OnPieceAct(piece, dest);
             if (isCapture)
                 effector.OnPieceCapture(piece, dest);
@@ -738,14 +756,26 @@ public class BoardManager : MonoBehaviour
     {
         if (!tileEffectors.TryGetValue(pos, out var list)) return;
         foreach (var effector in new List<TileEffector>(list))
+        {
+            // 저장된(일시정지된) 타일 효과는 진입 트리거를 무시합니다.
+            if (effector == null || effector.IsSuspended)
+                continue;
+
             effector.OnPieceEnter(piece);
+        }
     }
 
     private void TriggerTileExit(Vector3Int pos, Piece piece)
     {
         if (!tileEffectors.TryGetValue(pos, out var list)) return;
         foreach (var effector in new List<TileEffector>(list))
+        {
+            // 저장된(일시정지된) 타일 효과는 이탈 트리거를 무시합니다.
+            if (effector == null || effector.IsSuspended)
+                continue;
+
             effector.OnPieceExit(piece);
+        }
     }
 
     /// <summary>보드 위 모든 기물 목록을 반환합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -24,6 +24,9 @@ public class GameManager : MonoBehaviour
     public bool IsEndGame { get; private set; } = false;
     public bool IsArenaMode { get; set; } = false;
     private List<(int turn, Action action)> recievedActions = new List<(int, Action)>();
+    // 투기장 진행 중 기존 예약 액션(폭탄, 지속효과 해제 등) 소모를 잠시 멈춥니다.
+    private bool areQueuedActionsPaused = false;
+    private int queuedActionPauseTurn = -1;
 
     /// <summary>플레이어 턴이 시작되고 CanMovePos가 유효해진 직후 발행됩니다.</summary>
     public event Action OnPlayerTurnStarted;
@@ -288,6 +291,9 @@ public class GameManager : MonoBehaviour
     /// </summary>
     public void ReturnAction()
     {
+        if (areQueuedActionsPaused)
+            return;
+
         for (int i = recievedActions.Count - 1; i >= 0; i--)
         {
             var item = recievedActions[i];
@@ -299,6 +305,39 @@ public class GameManager : MonoBehaviour
             }
         }
 
+    }
+
+    /// <summary>예약 액션 소모를 일시 정지합니다.</summary>
+    public void PauseQueuedActions()
+    {
+        if (areQueuedActionsPaused)
+            return;
+
+        areQueuedActionsPaused = true;
+        queuedActionPauseTurn = curTurn;
+    }
+
+    /// <summary>
+    /// 예약 액션 소모를 재개합니다.
+    /// 일시정지 중 흘러간 턴 수만큼 예약 트리거 턴을 뒤로 밀어, 남은 지속 턴을 보존합니다.
+    /// </summary>
+    public void ResumeQueuedActions()
+    {
+        if (!areQueuedActionsPaused)
+            return;
+
+        int delta = curTurn - queuedActionPauseTurn;
+        if (delta != 0)
+        {
+            for (int i = 0; i < recievedActions.Count; i++)
+            {
+                var item = recievedActions[i];
+                recievedActions[i] = (item.turn + delta, item.action);
+            }
+        }
+
+        areQueuedActionsPaused = false;
+        queuedActionPauseTurn = -1;
     }
     // MoveSelected 안에서 플레이어 수 적용 후:
     private void MoveSelected(Vector3Int target)

--- a/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using DG.Tweening;
 
@@ -233,7 +232,7 @@ public class Piece : MonoBehaviour
     {
         var copy = new List<Action<Vector3Int>>(onCaptureEffects);
 
-        foreach (var eff in GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        foreach (var eff in GetComponents<IPieceEffect>())
         {
             eff.OnPieceCapture();
         }

--- a/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DG.Tweening;
 
@@ -232,7 +233,10 @@ public class Piece : MonoBehaviour
     {
         var copy = new List<Action<Vector3Int>>(onCaptureEffects);
 
-        GetComponent<IPieceEffect>()?.OnPieceCapture();
+        foreach (var eff in GetComponents<MonoBehaviour>().OfType<IPieceEffect>())
+        {
+            eff.OnPieceCapture();
+        }
 
         foreach (var effect in copy)
         {

--- a/ChaosChess_v2/ChaosChess_v2.slnx
+++ b/ChaosChess_v2/ChaosChess_v2.slnx
@@ -1,0 +1,5 @@
+﻿<Solution>
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-firstpass.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
+</Solution>


### PR DESCRIPTION
# 개요
투기장 진입/종료 시 타일, 전역 카드 효과 저장/불러오기 기능을 구현했습니다.

## 기타 사항
무하한 효과에 있는 TileEffector는 투기장에 가도 유지되도록 예외 처리 했습니다.

- main에 잘못 merge되어 revert했습니다.
- develop에 다시 PR합니다.
- 기존 PR: #136