### PR TITLE
[Fix] 카드 버그들 수정

### DIFF
--- a/ChaosChess_v2/Assets/Script/Card/SO/DimensionInstabilityCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/DimensionInstabilityCard.asset
@@ -22,16 +22,19 @@ MonoBehaviour:
   CardTier: 3
   PieceType: 2
   PieceTargetColor: 0
-  PieceLimitTurn: 1
+  PieceLimitTurn: -1
   RequiredPieceCount: 1
   TileCount: 0
   MaintainTurn: 0
+  NeedEffectTileBase: 0
+  EffectTileBase: {fileID: 0}
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
+  ShowStatusCard: 0
   NeedAdditionalDescription: 1
   DescriptionType: 1
   AdditionalDescriptionTitle: "\uAC00\uC0C1\uC758 \uB098\uC774\uD2B8"

--- a/ChaosChess_v2/Assets/Script/Card/SO/ReviveCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ReviveCard.asset
@@ -16,7 +16,9 @@ MonoBehaviour:
   CardImage: {fileID: 0}
   CardDescription: "\uD134\uC744 \uC18C\uBAA8\uD574\uC11C \uC790\uC2E0\uC758 \uC8FD\uC740
     \uAE30\uBB3C \uC911 \uAC00\uC7A5 \uAC00\uCE58\uAC00 \uB192\uC740 \uAE30\uBB3C\uC744
-    \uC120\uD0DD\uD55C \uD0C0\uC77C\uC5D0\uC11C \uBD80\uD65C\uC2DC\uD0B5\uB2C8\uB2E4."
+    \uC120\uD0DD\uD55C \uD0C0\uC77C\uC5D0\uC11C \uBD80\uD65C\uC2DC\uD0B5\uB2C8\uB2E4.\n\uB9CC\uC57D
+    \uC8FD\uC740 \uAE30\uBB3C\uC774 \uC5C6\uC73C\uBA74 \uADF8 \uC790\uB9AC\uC5D0
+    \uBCBD\uC744 \uC0DD\uC131\uD569\uB2C8\uB2E4."
   Type: 1
   CardTier: 4
   PieceType: 12
@@ -25,14 +27,17 @@ MonoBehaviour:
   RequiredPieceCount: 1
   TileCount: 1
   MaintainTurn: 0
+  NeedEffectTileBase: 0
+  EffectTileBase: {fileID: 0}
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
+  ShowStatusCard: 0
   NeedAdditionalDescription: 0
-  DescriptionType: 0
+  DescriptionType: 1
   AdditionalDescriptionTitle: 
   PieceDescImage: {fileID: 0}
   MovementImage: {fileID: 0}

--- a/ChaosChess_v2/Assets/Script/Card/Skills/DimensionInstabilityCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/DimensionInstabilityCard.cs
@@ -25,7 +25,6 @@ public class DimensionInstabilityCard : CardData, IPieceCard
         Piece piece = args.Targets[0];
         var effector = CreatePieceEffector<DimensionInstabilityEffector>(piece);
         effector.Apply();
-        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, effector.Revert);
     }
 }
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
@@ -14,13 +14,13 @@ class ConcentrationEffector : PieceEffector
     }
     protected override void OnApply()
     {
-        BoardManager.Instance.ChangePiece(piece.Pos,piece.Color,'a');
+        piece.FenOverride = "a";
     }
 
     protected override void OnRevert()
     {
-        if(piece)
-            BoardManager.Instance.ChangePiece(piece.Pos,piece.Color,'s');
+        if (piece)
+            BoardManager.Instance.ChangePiece(piece.Pos, piece.Color, 's');
         Destroy(this);
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -357,6 +357,10 @@ public class GameManager : MonoBehaviour
             {
                 if (extraPlayerActions > 0)
                 {
+                    // 데스페라도 추가 행동 중에도, 이미 상대가 체크메이트면 즉시 게임 종료합니다.
+                    if (TryApplyImmediateOpponentCheckmate())
+                        return;
+
                     extraPlayerActions--;
                     RefreshPlayerTurn();
                 }
@@ -368,6 +372,39 @@ public class GameManager : MonoBehaviour
                 }
             });
         }
+    }
+
+    /// <summary>
+    /// 현재 보드에서 "상대 턴" 기준으로 체크메이트를 판정해 즉시 승패를 적용합니다.
+    /// 데스페라도처럼 턴을 넘기지 않는 추가 행동 분기에서 사용합니다.
+    /// </summary>
+    private bool TryApplyImmediateOpponentCheckmate()
+    {
+        BoardManager.Instance.UpdateFEN();
+        string currentFen = BoardManager.Instance.GetFEN();
+
+        string[] fenParts = currentFen.Split(' ');
+        if (fenParts.Length < 2)
+            return false;
+
+        string originalTurn = fenParts[1];
+        fenParts[1] = (originalTurn == "w") ? "b" : "w";
+        string opponentTurnFen = string.Join(" ", fenParts);
+
+        FairyStockfishBridge.Instance.SetPosition(opponentTurnFen);
+        string[] opponentMoves = FairyStockfishBridge.Instance.GetLegalMoves();
+        bool opponentInCheck = FairyStockfishBridge.Instance.IsInCheck();
+
+        // 이후 흐름을 위해 엔진 포지션을 원래 턴 상태로 복원합니다.
+        FairyStockfishBridge.Instance.SetPosition(currentFen);
+
+        if (opponentMoves.Length == 0 && opponentInCheck)
+        {
+            OnSurrender(EnemyColor);
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>현재 보드 상태를 Stockfish에 동기화합니다. 투기장 종료 후 기물 복원 시 사용합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -189,6 +189,7 @@ public class GameManager : MonoBehaviour
         FairyStockfishBridge.Instance.GetLegalMovesAsync(moves =>
         {
             EvaluateGameState(moves);
+            ApplyGameResult();
             BoardManager.Instance.UpdatePiecesCanMovePos(moves);
             OnPlayerTurnStarted?.Invoke();
         });


### PR DESCRIPTION
# 개요
카드의 버그들을 수정하였습니다.

해결한 이슈 : 
- #113 
- #120 
- #123 
- #124
 
## 차원 불안 
차원 불안 SO의 효과 유지 턴을 1에서 -1로 수정해서 해결했습니다.

## 데스페라도
게임메니저에 추가 행동을 할때 상대가 체크메이트를 당했는지 확인하는 메서드 추가해서 해결했습니다.

## 부활
부활 SO에 죽은 기물이 없으면 벽을 생성한다는 문구를 추가했습니다.

## 정신 집중
ChangePiece를 하면서 piece값이 null이 되는 것이 원인 이였습니다.

그래서 카드를 사용할 때는 piece의 FenOverride 값을 벽인 "a"로 수정하고,
다섯 턴 이 지나고 난 후에 효과가 발동하면 ChangePiece를 이용해 아마존으로 변하게 수정해서 해결했습니다.