### PR TITLE
[Bug] 무승부 시스템 수정

### DIFF
--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -452,6 +452,10 @@ public class GameManager : MonoBehaviour
         {
             FinishType = GameResult.Draw;
         }
+        if (FairyStockfishBridge.Instance.IsInsufficientMaterial())
+        {
+            FinishType = GameResult.Draw;
+        }
         bool isCheck = FairyStockfishBridge.Instance.IsInCheck();
 
 

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -452,7 +452,7 @@ public class GameManager : MonoBehaviour
         {
             FinishType = GameResult.Draw;
         }
-        if (FairyStockfishBridge.Instance.IsInsufficientMaterial())
+        else if (FairyStockfishBridge.Instance.IsInsufficientMaterial())
         {
             FinishType = GameResult.Draw;
         }


### PR DESCRIPTION
#143

## 개요
기물 부족 무승부가 동작하지 않던 문제를 수정했습니다.

## 변경 사항
- EvaluateGameState에 기물 부족 판정 추가

## 기타 사항
특수 기물(벽)은 카드 사용을 통해서만 등장하기 때문에 카드 효과가 발생하면,
다시 기물 부족 상태가 아니게 되므로 별도의 커스텀 판정 없이 기존 로직을 그대로 사용했습니다.