### PR TITLE
[Fix] 기물 파괴 시 참조 효과 오브젝트 미정리로 인한 게임 멈춤 현상 수정

### DIFF
--- a/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
@@ -83,6 +83,7 @@ public class FireEffect : TileEffector
 
     private void OnDestroy()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
         boardManager.UnregisterTileEffector(tilePos, this);
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
@@ -34,6 +34,8 @@ public class FireEffect : TileEffector
 
     protected override void OnApply()
     {
+        Piece.OnPieceDestroyed += HandlePieceDestroyed;
+
         // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
@@ -43,11 +45,18 @@ public class FireEffect : TileEffector
 
     protected override void OnRevert()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+
         // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
 
         Destroy(gameObject);
+    }
+
+    private void HandlePieceDestroyed(Piece piece)
+    {
+        if (piece == enterPiece) { enterPiece = null; Revert(); }
     }
 
     public override void OnPieceEnter(Piece piece)

--- a/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
@@ -78,6 +78,7 @@ public class ObeyOrderEffect : TileEffector
     // Revert()를 거치지 않고 오브젝트가 파괴되는 예외적 경로 대비
     private void OnDestroy()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
         UnsubscribeFromTurnEvent();
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
@@ -46,6 +46,8 @@ public class ObeyOrderEffect : TileEffector
 
     protected override void OnApply()
     {
+        Piece.OnPieceDestroyed += HandlePieceDestroyed;
+
         // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
@@ -55,6 +57,8 @@ public class ObeyOrderEffect : TileEffector
 
     protected override void OnRevert()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+
         // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
@@ -64,6 +68,11 @@ public class ObeyOrderEffect : TileEffector
         _state = ObeyState.Idle;
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
+    }
+
+    private void HandlePieceDestroyed(Piece piece)
+    {
+        if (piece == enterPiece) { enterPiece = null; Revert(); }
     }
 
     // Revert()를 거치지 않고 오브젝트가 파괴되는 예외적 경로 대비

--- a/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
@@ -131,6 +131,12 @@ public class SyncChild : TileEffector
         if (piece == SynchronizedPiece) Revert();
     }
 
+    // Revert()를 거치지 않고 오브젝트가 파괴되는 예외적 경로 대비
+    private void OnDestroy()
+    {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+    }
+
     /// <summary>동기화 기물을 설정하고 타일 감시를 시작합니다.</summary>
     public void Activate(Piece synced)
     {

--- a/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
@@ -104,6 +104,8 @@ public class SyncChild : TileEffector
 
     protected override void OnApply()
     {
+        Piece.OnPieceDestroyed += HandlePieceDestroyed;
+
         // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
@@ -113,6 +115,8 @@ public class SyncChild : TileEffector
 
     protected override void OnRevert()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+
         // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
@@ -120,6 +124,11 @@ public class SyncChild : TileEffector
         SynchronizedPiece = null;
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
+    }
+
+    private void HandlePieceDestroyed(Piece piece)
+    {
+        if (piece == SynchronizedPiece) Revert();
     }
 
     /// <summary>동기화 기물을 설정하고 타일 감시를 시작합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
@@ -47,21 +47,30 @@ public class BlessingEffect : TileEffector
 
     protected override void OnApply()
     {
+        Piece.OnPieceDestroyed += HandlePieceDestroyed;
+
         // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
-            
+
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+
         // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
+    }
+
+    private void HandlePieceDestroyed(Piece piece)
+    {
+        if (piece == currentPiece) { currentPiece = null; Revert(); }
     }
 
     public override void OnPieceEnter(Piece piece)

--- a/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
@@ -73,6 +73,12 @@ public class BlessingEffect : TileEffector
         if (piece == currentPiece) { currentPiece = null; Revert(); }
     }
 
+    // Revert()를 거치지 않고 오브젝트가 파괴되는 예외적 경로 대비
+    private void OnDestroy()
+    {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+    }
+
     public override void OnPieceEnter(Piece piece)
     {
         SchedulePromotion(piece);

--- a/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
@@ -19,8 +19,8 @@ class ConcentrationEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        if (piece)
-            BoardManager.Instance.ChangePiece(piece.Pos, piece.Color, 's');
+        if (target != null)
+            BoardManager.Instance.ChangePiece(target.Pos, target.Color, 's');
         Destroy(this);
     }
 }
@@ -46,6 +46,6 @@ public class ConcentrationCard : CardData, IPieceCard
         var effector = CreatePieceEffector<ConcentrationEffector>(piece);
         effector.Init(piece);
         effector.Apply();
-        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, effector.Revert);
+        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, () => { if (effector != null) effector.Revert(); });
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/DarkHandCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/DarkHandCard.cs
@@ -25,7 +25,7 @@ public class DarkHandCard : CardData, IPieceCard
         Piece piece = args.Targets[0];
         var effector = CreatePieceEffector<DarkHandEffector>(piece);
         effector.Apply();
-        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, effector.Revert);
+        GameManager.Instance.AppendAction(DataSO.PieceLimitTurn, () => { if (effector != null) effector.Revert(); });
     }
 }
 
@@ -39,7 +39,7 @@ public class DarkHandEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.FenOverride = null;
+        if (target != null) target.FenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/StagFightCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/StagFightCard.cs
@@ -61,4 +61,10 @@ public class StagFightEffector : GlobalEffector
     }
 
     private void HandlePieceDestroyed(Piece piece) => changed.Remove(piece);
+
+    // Revert()를 거치지 않고 오브젝트가 파괴되는 예외적 경로 대비
+    private void OnDestroy()
+    {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
+    }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/StagFightCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/StagFightCard.cs
@@ -30,6 +30,7 @@ public class StagFightEffector : GlobalEffector
 
     protected override void OnApply()
     {
+        Piece.OnPieceDestroyed += HandlePieceDestroyed;
         List<Piece> pieces = BoardManager.Instance.GetAllPieces();
         foreach (Piece piece in pieces)
         {
@@ -48,6 +49,7 @@ public class StagFightEffector : GlobalEffector
 
     protected override void OnRevert()
     {
+        Piece.OnPieceDestroyed -= HandlePieceDestroyed;
         foreach (Piece piece in changed)
         {
             string p = piece.MoveFenOverride?.ToLower();
@@ -57,4 +59,6 @@ public class StagFightEffector : GlobalEffector
         BoardManager.Instance.RefreshMoves();
         Destroy(gameObject);
     }
+
+    private void HandlePieceDestroyed(Piece piece) => changed.Remove(piece);
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -493,6 +493,7 @@ public class BoardManager : MonoBehaviour
             eff.OnPieceCaptured();
         }
         Pieces.Remove(piece);
+        Piece.InvokeOnPieceDestroyed(piece);
         Destroy(piece.gameObject);
 
         if (refresh) RefreshMoves();

--- a/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
@@ -11,6 +11,10 @@ public enum PieceColor
 
 public class Piece : MonoBehaviour
 {
+    /// <summary>BoardManager.DestroyPiece()가 호출될 때 파괴되는 기물을 인자로 발화합니다.</summary>
+    public static event Action<Piece> OnPieceDestroyed;
+    internal static void InvokeOnPieceDestroyed(Piece piece) => OnPieceDestroyed?.Invoke(piece);
+
     // 무언갈 잡을때 효과 발동
     private List<Action<Vector3Int>> onCaptureEffects = new();
 


### PR DESCRIPTION
# 개요

기물이 외부 카드 효과(TimeBomb, CheckmateDeclaration 등)로 파괴될 때, 해당 기물을 `Piece` 레퍼런스로 보유하고 있는 TileEffector/GlobalEffector가 알림을 받지 못했습니다.

이후 해당 효과들이 `OnTurnChanged` 또는 `OnRevert` 에서 이미 파괴된 기물의 프로퍼티에 접근하면 `MissingReferenceException`이 발생하고, 이 예외가 `GameManager.OnTurnChanged?.Invoke()` 이벤트 체인 중에 전파되어 **게임이 멈추는 현상**을 유발했습니다.

# 내용

## Piece.OnPieceDestroyed 이벤트 추가 (Piece.cs, BoardManager.cs)

- `Piece`에 `public static event Action<Piece> OnPieceDestroyed` 정적 이벤트 추가
- `BoardManager.DestroyPiece()` 내 `Destroy(piece.gameObject)` 직전에 이벤트 발화
- 이를 통해 기물 참조를 보유한 모든 효과가 일관된 방식으로 정리될 수 있는 기반 마련

## TileEffector / GlobalEffector 자동 정리 (5개 카드)

각 효과의 `OnApply()`에서 `OnPieceDestroyed` 이벤트를 구독하고, `OnRevert()`에서 해제합니다. 추적 중인 기물이 파괴되면 즉시 대응합니다.

| 효과 클래스 | 추적 필드 | 파괴 시 동작 |
|---|---|---|
| `StagFightEffector` | `List<Piece> changed` | 리스트에서 제거 (효과 계속 유지) |
| `FireEffect` | `enterPiece` | `Revert()` |
| `ObeyOrderEffect` | `enterPiece` | `Revert()` |
| `BlessingEffect` | `currentPiece` | `Revert()` |
| `SyncChild` | `SynchronizedPiece` | `Revert()` |

> `StagFightEffector`는 여러 기물을 동시에 추적하므로, 파괴된 기물만 제거하고 나머지 기물에 대한 효과는 유지합니다.

## PieceEffector + AppendAction 패턴 null-guard 추가 (DarkHandCard, ConcentrationCard)

기물이 잡히면 `PieceEffector` 컴포넌트도 같이 파괴되는데, `AppendAction`으로 예약된 `effector.Revert` 콜백이 나중에 파괴된 컴포넌트를 호출하여 `MissingReferenceException`이 발생하는 문제를 수정했습니다.

- `AppendAction` 콜백을 `() => { if (effector != null) effector.Revert(); }` 형태로 변경
- `OnRevert()` 내 `target` 접근 시 null 체크 추가

# 기타 사항

`DarkHandEffector`도 동일한 패턴의 버그가 있었으며 함께 수정되었습니다.