### PR TITLE
[Feature] 투기장 사용 시 남은 턴 수 보여주는 UI 추가

### DIFF
--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System;
 using System.Linq;
 using Unity.VisualScripting;
 using UnityEngine;
@@ -24,9 +25,16 @@ public enum ArenaResult { PlayerWon, Timeout, OpponentCheckmated }
 /// </summary>
 public class ArenaManager : MonoBehaviour
 {
+    private const int MaxPlayerMoveCount = 8;
+
     public static ArenaManager Instance;
+    internal event Action<CardDataSO, int> ArenaStarted;
+    internal event Action<int> ArenaRemainingTurnsChanged;
+    internal event Action ArenaEnded;
+
     /// <summary>투기장 시작 전 저장된(일시정지된) 타일/전역 효과가 존재하는지 여부입니다.</summary>
     public bool AreStoredEffectsSuspended => isArenaActive && suspendedEffects.Count > 0;
+    private int RemainingPlayerMoves => Mathf.Max(0, MaxPlayerMoveCount - playerMoveCount);
 
     // 투기장 참가 기물
     private List<Piece> opponentArenaPieces = new();  // 상대 투기장 기물 (최대 3개)
@@ -59,7 +67,7 @@ public class ArenaManager : MonoBehaviour
     /// 투기장을 시작합니다.
     /// </summary>
     /// <param name="opponents">투기장에 참여할 상대 기물 목록 (최대 3개)</param>
-    public void StartArena(List<Piece> opponents)
+    public void StartArena(List<Piece> opponents, CardDataSO arenaCardSO = null)
     {
         if (isArenaActive) return;
         isArenaActive = true;
@@ -116,6 +124,8 @@ public class ArenaManager : MonoBehaviour
 
         // 반턴 이벤트 구독으로 포획 감지 및 턴 카운트
         gm.OnHalfTurnChanged += OnHalfTurnChanged;
+
+        ArenaStarted?.Invoke(arenaCardSO, RemainingPlayerMoves);
     }
 
     /// <summary>
@@ -142,7 +152,9 @@ public class ArenaManager : MonoBehaviour
         if (!GameManager.Instance.IsPlayerTurn)
         {
             playerMoveCount++;
-            if (playerMoveCount >= 8)
+            ArenaRemainingTurnsChanged?.Invoke(RemainingPlayerMoves);
+
+            if (playerMoveCount >= MaxPlayerMoveCount)
                 EndArena(ArenaResult.Timeout);
         }
     }
@@ -162,6 +174,7 @@ public class ArenaManager : MonoBehaviour
         gm.OnHalfTurnChanged -= OnHalfTurnChanged;
         gm.IsArenaMode = false;
         gm.SetLockedPiece(null);
+        ArenaEnded?.Invoke();
 
         // King 무적 해제 — 메인 게임 복귀 후 King이 정상적으로 포획될 수 있어야 함
         playerKing?.ConsumeInvincibility();

--- a/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
@@ -24,6 +24,6 @@ public class ArenaCard : CardData, ICard
         }
 
         List<Piece> arenaOpponents = opponents.GetRange(0, Mathf.Min(3, opponents.Count));
-        ArenaManager.Instance.StartArena(arenaOpponents);
+        ArenaManager.Instance.StartArena(arenaOpponents, DataSO);
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/ButtonPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/ButtonPanel.cs
@@ -12,14 +12,14 @@ public class ButtonPanel : MonoBehaviour
     private bool isDisabled = false;
     private CanvasGroup canvasGroup;
 
-    private void Awake()
+    protected virtual void Awake()
     {
         canvasGroup = GetComponent<CanvasGroup>();
     }
 
     private void Start()
     {
-        if(!baseEnabled) DisablePanel();
+        if (!baseEnabled) DisablePanel();
     }
 
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
@@ -28,8 +28,9 @@ public class CardDescPanel : ButtonPanel
 
     private CardAnim selectedCard;
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
         TryAutoBindTierUI();
     }
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/GlobalCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/GlobalCardDisplay.cs
@@ -15,12 +15,21 @@ public class GlobalCardDisplay : MonoBehaviour
     [SerializeField] private GameObject cardPrefab;
 
     private readonly Dictionary<GlobalEffector, GlobalCardData> _displayedCards = new();
+    private GlobalCardData _arenaCard;
+    private bool _isArenaCardDisplayed;
+    private ArenaManager _subscribedArenaManager;
 
     private void OnEnable()
     {
         GlobalEffector.OnActivated += HandleActivated;
         GlobalEffector.OnDeactivated += HandleDeactivated;
         GlobalEffector.OnTurnTicked += HandleTurnTicked;
+        TrySubscribeArenaManager();
+    }
+
+    private void Start()
+    {
+        TrySubscribeArenaManager();
     }
 
     private void OnDisable()
@@ -28,6 +37,30 @@ public class GlobalCardDisplay : MonoBehaviour
         GlobalEffector.OnActivated -= HandleActivated;
         GlobalEffector.OnDeactivated -= HandleDeactivated;
         GlobalEffector.OnTurnTicked -= HandleTurnTicked;
+        UnsubscribeArenaManager();
+    }
+
+    private void TrySubscribeArenaManager()
+    {
+        if (_subscribedArenaManager != null) return;
+
+        ArenaManager arenaManager = ArenaManager.Instance;
+        if (arenaManager == null) return;
+
+        _subscribedArenaManager = arenaManager;
+        _subscribedArenaManager.ArenaStarted += HandleArenaStarted;
+        _subscribedArenaManager.ArenaRemainingTurnsChanged += HandleArenaRemainingTurnsChanged;
+        _subscribedArenaManager.ArenaEnded += HandleArenaEnded;
+    }
+
+    private void UnsubscribeArenaManager()
+    {
+        if (_subscribedArenaManager == null) return;
+
+        _subscribedArenaManager.ArenaStarted -= HandleArenaStarted;
+        _subscribedArenaManager.ArenaRemainingTurnsChanged -= HandleArenaRemainingTurnsChanged;
+        _subscribedArenaManager.ArenaEnded -= HandleArenaEnded;
+        _subscribedArenaManager = null;
     }
 
     private void HandleActivated(GlobalEffector ge)
@@ -62,6 +95,58 @@ public class GlobalCardDisplay : MonoBehaviour
     private static string GetDisplayText(GlobalEffector ge) =>
         ge.IsPermanent ? "" : $"{ge.RemainingTurns}";
 
+    private void HandleArenaStarted(CardDataSO cardSO, int remainingTurns)
+    {
+        if (_isArenaCardDisplayed)
+            RemoveArenaCard();
+
+        var instance = Instantiate(cardPrefab, layout.areaBounds);
+
+        GlobalCardUI cardUI = instance.GetComponent<GlobalCardUI>();
+        RectTransform rect = instance.GetComponent<RectTransform>();
+
+        if (cardSO != null)
+            cardUI.CardImage.sprite = cardSO.CardImage;
+
+        cardUI.RemainTurn.text = $"{remainingTurns}";
+        cardUI.Title.text = "남은 턴";
+
+        _arenaCard = new GlobalCardData
+        {
+            Rt = rect,
+            CardUI = cardUI
+        };
+        _isArenaCardDisplayed = true;
+
+        layout.AddCard(_arenaCard.Rt);
+        cardUI.PlayAppearAnimation(() => layout.RefreshAnimated());
+    }
+
+    private void HandleArenaRemainingTurnsChanged(int remainingTurns)
+    {
+        if (!_isArenaCardDisplayed) return;
+
+        _arenaCard.CardUI.RemainTurn.text = $"{remainingTurns}";
+    }
+
+    private void HandleArenaEnded()
+    {
+        if (!_isArenaCardDisplayed) return;
+
+        RemoveArenaCard();
+    }
+
+    private void RemoveArenaCard()
+    {
+        GlobalCardData arenaCard = _arenaCard;
+        _isArenaCardDisplayed = false;
+        layout.RemoveCard(arenaCard.Rt);
+
+        var cg = arenaCard.Rt.GetComponent<CanvasGroup>();
+        cg.blocksRaycasts = false;
+        cg.DOFade(0f, arenaCard.CardUI.AnimationDuration).SetEase(Ease.InQuad);
+        arenaCard.CardUI.PlayDisappearAnimation(() => Destroy(arenaCard.Rt.gameObject));
+    }
 
     private void HandleDeactivated(GlobalEffector ge)
     {


### PR DESCRIPTION
## 개요
투기장 카드 사용 중 남은 진행 턴을 전역 카드 상태 UI에 표시하도록 구현했습니다.

## 기타 사항
- `ArenaManager`에서 투기장 시작, 남은 턴 변경, 종료 시점을 이벤트로 추가했습니다.
- `ArenaCard` 실행 시 카드 SO를 `ArenaManager`에 전달해 UI에서 투기장 카드 이미지/정보를 재사용할 수 있게 했습니다.
- 투기장 종료 시 표시 중인 투기장 상태 카드를 기존 전역 카드와 동일한 애니메이션으로 제거합니다.