### PR TITLE
[Fix] 게임 씬 UI 관련 이슈 해결

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -846,7 +846,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 160654729}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -1899,11 +1899,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1354996648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -4.9, y: -118.899956}
-  m_SizeDelta: {x: 1749.2, y: 237.8}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -4.9, y: -344.99988}
+  m_SizeDelta: {x: 1749.2, y: 237.79999}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &402923178
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1970,7 +1970,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -2255,7 +2255,7 @@ MonoBehaviour:
   enableCanvas: {fileID: 0}
   disablePanel: {fileID: 0}
   enablePanel: {fileID: 0}
-  buttonType: 6
+  buttonType: 0
   practiceDifficulty: 1
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
@@ -2924,11 +2924,11 @@ RectTransform:
   - {fileID: 160654730}
   m_Father: {fileID: 1354996648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -330.7, y: 150}
-  m_SizeDelta: {x: 1097.5, y: 220.2}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -330.7, y: -85}
+  m_SizeDelta: {x: 1097.5, y: 220.20001}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &568295689
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3648,10 +3648,10 @@ RectTransform:
   - {fileID: 617903360}
   m_Father: {fileID: 1399380570}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -45}
+  m_SizeDelta: {x: 1920, y: 4054}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &647750785
 CanvasRenderer:
@@ -4105,11 +4105,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1354996648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -330.69998, y: -118.899956}
-  m_SizeDelta: {x: 1097.5, y: 237.8}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -330.69998, y: -344.99988}
+  m_SizeDelta: {x: 1097.5, y: 237.79999}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &834550414
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4176,7 +4176,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 0
@@ -6005,7 +6005,7 @@ MonoBehaviour:
   enableCanvas: {fileID: 0}
   disablePanel: {fileID: 0}
   enablePanel: {fileID: 0}
-  buttonType: 6
+  buttonType: 0
   practiceDifficulty: 1
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
@@ -7184,11 +7184,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1354996648}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 586, y: 0.050022}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 586, y: -85}
   m_SizeDelta: {x: 520.1, y: 520.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1229241282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7965,6 +7965,7 @@ GameObject:
   - component: {fileID: 1354996648}
   - component: {fileID: 1354996650}
   - component: {fileID: 1354996649}
+  - component: {fileID: 2147001013}
   m_Layer: 5
   m_Name: SubDesc
   m_TagString: Untagged
@@ -7989,13 +7990,14 @@ RectTransform:
   - {fileID: 1229241281}
   - {fileID: 834550413}
   - {fileID: 402923177}
+  - {fileID: 2147001001}
   m_Father: {fileID: 1686426950}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1920, y: 626.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1354996649
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8300,8 +8302,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1979229017}
-  - {fileID: 647750783}
   - {fileID: 1686426950}
+  - {fileID: 647750783}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -8317,7 +8319,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1399380566}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
@@ -8356,6 +8358,7 @@ MonoBehaviour:
   subDescMovementImage: {fileID: 1229241282}
   subDescPieceContent: {fileID: 834550414}
   subDescContent: {fileID: 402923178}
+  subDescFoldController: {fileID: 2147001013}
 --- !u!1 &1422633467
 GameObject:
   m_ObjectHideFlags: 0
@@ -9857,7 +9860,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1686426950}
   - component: {fileID: 1686426952}
-  - component: {fileID: 1686426953}
   m_Layer: 5
   m_Name: SubDescPanel
   m_TagString: Untagged
@@ -9882,9 +9884,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 1340.6}
-  m_SizeDelta: {x: 1920, y: 1372.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 1410}
+  m_SizeDelta: {x: 1920, y: 690}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1686426952
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -9893,32 +9895,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1686426949}
   m_CullTransparentMesh: 1
---- !u!114 &1686426953
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1686426949}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 7
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &1687492016
 GameObject:
   m_ObjectHideFlags: 0
@@ -11709,7 +11685,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 8280881136048196920, guid: 0a6f0fa984d61d444845f64a43c506ca, type: 3}
+  m_Sprite: {fileID: -6601691336363857274, guid: 2c3d4943bf5992a42a32e8460ada962d, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -17596,6 +17572,389 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2143107745}
   m_CullTransparentMesh: 1
+--- !u!1 &2147001000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2147001001}
+  - component: {fileID: 2147001002}
+  - component: {fileID: 2147001003}
+  - component: {fileID: 2147001008}
+  m_Layer: 5
+  m_Name: MoreToggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2147001001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2147001009}
+  - {fileID: 2147001005}
+  m_Father: {fileID: 1354996648}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 460, y: 116}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &2147001002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001000}
+  m_CullTransparentMesh: 1
+--- !u!114 &2147001003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.05882353, g: 0.05882353, b: 0.05882353, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2147001004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2147001005}
+  - component: {fileID: 2147001006}
+  - component: {fileID: 2147001007}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2147001005
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2147001001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 180, y: 96}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2147001006
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001004}
+  m_CullTransparentMesh: 1
+--- !u!114 &2147001007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: v
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
+  m_sharedMaterial: {fileID: 2683479388609967759, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 96
+  m_fontSizeBase: 96
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2147001008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2147001003}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2147001013}
+        m_TargetAssemblyTypeName: SubDescFoldController, Assembly-CSharp
+        m_MethodName: Toggle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  clickSound: {fileID: 0}
+  hoverSound: {fileID: 0}
+  disableCanvas: {fileID: 0}
+  enableCanvas: {fileID: 0}
+  disablePanel: {fileID: 0}
+  enablePanel: {fileID: 0}
+  buttonType: 0
+  practiceDifficulty: 1
+  uIAnimationObject: {fileID: 0}
+  isStartAnimation: 0
+  isEndAnimation: 0
+  nextSceneName: 
+  practiceSceneName: MainGameScene
+  rewardSceneName: RewardScene
+  resultSceneName: ResultScene
+  mainSceneName: MainScene
+--- !u!224 &2147001009
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001010}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2147001001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 6}
+  m_SizeDelta: {x: 0, y: 12}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2147001010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2147001009}
+  - component: {fileID: 2147001011}
+  - component: {fileID: 2147001012}
+  m_Layer: 5
+  m_Name: Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &2147001011
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001010}
+  m_CullTransparentMesh: 1
+--- !u!114 &2147001012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147001010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da278b4ad962ea49b52e728dab946b4, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!114 &2147001013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1354996647}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12e62f6d7d1f4ed4a86d759c0d5ef4d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  subDescRoot: {fileID: 1686426950}
+  pushedContentRoot: {fileID: 647750783}
+  moreToggle: {fileID: 2147001000}
+  moreToggleIcon: {fileID: 2147001007}
+  pieceDescriptionText: {fileID: 834550414}
+  ruleDescriptionText: {fileID: 402923178}
+  minExpandHeight: 0
+  maxExpandHeight: 640
+  overflowPadding: 32
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -72,12 +72,14 @@ public class ArenaManager : MonoBehaviour
         if (isArenaActive) return;
         isArenaActive = true;
 
+        GameManager gm = GameManager.Instance;
+        gm.CancelCurrentSelectionForBoardTransition();
+
         opponentArenaPieces = opponents;
         playerMoveCount = 0;
         hiddenPieces.Clear();
 
         BoardManager bm = BoardManager.Instance;
-        GameManager gm = GameManager.Instance;
         var allPiece = bm.GetAllPieces();
 
         // 아레나 시작 시 모든 기물 위치 저장 (Timeout 시 완전 복원에 사용)
@@ -125,6 +127,9 @@ public class ArenaManager : MonoBehaviour
         // 반턴 이벤트 구독으로 포획 감지 및 턴 카운트
         gm.OnHalfTurnChanged += OnHalfTurnChanged;
 
+        // 투기장 보드 최종 상태에서 1회만 동기화
+        gm.SyncPositionToStockfish();
+
         ArenaStarted?.Invoke(arenaCardSO, RemainingPlayerMoves);
     }
 
@@ -169,6 +174,7 @@ public class ArenaManager : MonoBehaviour
         isArenaActive = false;
 
         GameManager gm = GameManager.Instance;
+        gm.CancelCurrentSelectionForBoardTransition();
 
         // 이벤트 구독 해제 및 투기장 모드 비활성화
         gm.OnHalfTurnChanged -= OnHalfTurnChanged;
@@ -209,18 +215,19 @@ public class ArenaManager : MonoBehaviour
         BoardManager.Instance.TileEffectDrawer.RestoreTileEffects(savedTileEffects);
         gm.ResumeQueuedActions();
 
+        // 복원 완료 최종 상태에서 1회만 동기화
+        gm.SyncPositionToStockfish();
+
         switch (result)
         {
             case ArenaResult.PlayerWon:
                 // 상대 투기장 기물은 이미 DestroyPiece()로 제거된 상태이므로 추가 처리 불필요
                 Debug.Log("[Arena] 플레이어 승리 — 상대 투기장 기물 제거됨");
-                gm.SyncPositionToStockfish();
                 // RequestAIMove는 MoveSelected()가 NextTurn() 완료 후 호출 — 여기서 호출 시 GetLegalMoves와 충돌
                 break;
 
             case ArenaResult.Timeout:
                 Debug.Log("[Arena] 8턴 초과 — 무효, 메인 게임 재개");
-                gm.SyncPositionToStockfish();
                 // RequestAIMove는 MoveSelected()가 NextTurn() 완료 후 호출 — 여기서 호출 시 GetLegalMoves와 충돌
                 break;
 
@@ -260,8 +267,6 @@ public class ArenaManager : MonoBehaviour
             suspendedEffects.Add(effector);
             effector.SuspendForArena();
         }
-
-        bm.RefreshMoves();
     }
 
     /// <summary>투기장 전에 저장해 둔 타일/전역 효과를 다시 활성화합니다.</summary>
@@ -276,6 +281,5 @@ public class ArenaManager : MonoBehaviour
         }
 
         suspendedEffects.Clear();
-        BoardManager.Instance.RefreshMoves();
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Selector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector.cs
@@ -2,6 +2,31 @@
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
+public enum CardSelectionOwner
+{
+    None,
+    Piece,
+    Tile
+}
+
+public static class CardSelectionState
+{
+    private static CardSelectionOwner currentSelectionOwner = CardSelectionOwner.None;
+    public static bool IsLocked => currentSelectionOwner != CardSelectionOwner.None;
+
+    public static void Lock(CardSelectionOwner owner)
+    {
+        if (owner == CardSelectionOwner.None) return;
+        currentSelectionOwner = owner;
+    }
+
+    public static void Unlock(CardSelectionOwner owner)
+    {
+        if (currentSelectionOwner == owner)
+            currentSelectionOwner = CardSelectionOwner.None;
+    }
+}
+
 public abstract class Selector<T> : MonoBehaviour
 {
     [SerializeField] protected Tilemap tilemap;
@@ -22,6 +47,17 @@ public abstract class Selector<T> : MonoBehaviour
 
         mainCamera = Camera.main;
         cardRandomizer = FindFirstObjectByType<CardRandomizer>();
+    }
+
+    protected void LockCardSelection(CardSelectionOwner owner)
+    {
+        CardSelectionState.Lock(owner);
+    }
+
+    protected void UnlockCardSelection(CardSelectionOwner owner)
+    {
+        // 현재 잠금 소유자만 해제 가능하게 해서 Piece->Tile 전환 중 잠금이 풀리지 않게 합니다.
+        CardSelectionState.Unlock(owner);
     }
 
     public abstract void EnableSelector(CardData data);

--- a/ChaosChess_v2/Assets/Script/Card/Selector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector.cs
@@ -25,6 +25,11 @@ public static class CardSelectionState
         if (currentSelectionOwner == owner)
             currentSelectionOwner = CardSelectionOwner.None;
     }
+
+    public static void Reset()
+    {
+        currentSelectionOwner = CardSelectionOwner.None;
+    }
 }
 
 public abstract class Selector<T> : MonoBehaviour

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -153,6 +153,7 @@ public class PieceSelector : Selector<Piece>
 
 
         GameManager.Instance.IsGameInput = false;
+        LockCardSelection(CardSelectionOwner.Piece);
         selectorCanvas.enabled = true;
         selectState = true;
 
@@ -176,6 +177,7 @@ public class PieceSelector : Selector<Piece>
     protected override void DisableSelector()
     {
         GameManager.Instance.IsGameInput = true;
+        UnlockCardSelection(CardSelectionOwner.Piece);
         selectorCanvas.enabled = false;
         selectState = false;
 

--- a/ChaosChess_v2/Assets/Script/Card/Selector/TileSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/TileSelector.cs
@@ -124,6 +124,7 @@ public class TileSelector : Selector<Vector3Int>
         selectedTargets.Clear();
 
         GameManager.Instance.IsGameInput = false;
+        LockCardSelection(CardSelectionOwner.Tile);
         selectorCanvas.enabled = true;
         selectState = true;
 
@@ -136,6 +137,7 @@ public class TileSelector : Selector<Vector3Int>
     protected override void DisableSelector()
     {
         GameManager.Instance.IsGameInput = true;
+        UnlockCardSelection(CardSelectionOwner.Tile);
         selectorCanvas.enabled = false;
         selectState = false;
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ArenaCard.cs
@@ -11,6 +11,8 @@ public class ArenaCard : CardData, ICard
 {
     public void Execute(CardEffectArgs args = null)
     {
+        GameManager.Instance.CancelCurrentSelectionForBoardTransition();
+
         // 상대 King 제외 기물 중 랜덤 3개 선택
         List<Piece> opponents = BoardManager.Instance.GetAllPieces()
             .FindAll(p => p.Color == GameManager.Instance.EnemyColor

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -84,6 +84,7 @@ public class GameManager : MonoBehaviour
     private void Start()
     {
         IsEndGame = false;
+        CardSelectionState.Reset();
         boardUI = FindFirstObjectByType<BoardUI>();
         uiManager = FindFirstObjectByType<UIManager>();
 
@@ -160,8 +161,8 @@ public class GameManager : MonoBehaviour
         else
         {
             MoveSelected(pos);
-            boardUI.DeleteSelectTile();
-            boardUI.DeleteValidMoveTiles();
+            boardUI?.DeleteSelectTile();
+            boardUI?.DeleteValidMoveTiles();
         }
     }
 
@@ -345,8 +346,8 @@ public class GameManager : MonoBehaviour
         if (BoardManager.Instance.MovePiece(piece, target))
         {
             BoardManager.Instance.RefreshMoves();
-            boardUI.DeleteSelectTile();
-            boardUI.DeleteValidMoveTiles();
+            boardUI?.DeleteSelectTile();
+            boardUI?.DeleteValidMoveTiles();
 
             // 프로모션이면 여기서 멈춤
             if (!IsGameInput)

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -344,6 +344,8 @@ public class GameManager : MonoBehaviour
 
         if (BoardManager.Instance.MovePiece(piece, target))
         {
+            BoardManager.Instance.RefreshMoves();
+
             // 프로모션이면 여기서 멈춤
             if (!IsGameInput)
                 return;

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -345,6 +345,8 @@ public class GameManager : MonoBehaviour
         if (BoardManager.Instance.MovePiece(piece, target))
         {
             BoardManager.Instance.RefreshMoves();
+            boardUI.DeleteSelectTile();
+            boardUI.DeleteValidMoveTiles();
 
             // 프로모션이면 여기서 멈춤
             if (!IsGameInput)
@@ -412,6 +414,16 @@ public class GameManager : MonoBehaviour
         FairyStockfishBridge.Instance.SetPosition(fen);
         string[] moves = FairyStockfishBridge.Instance.GetLegalMoves();
         BoardManager.Instance.UpdatePiecesCanMovePos(moves);
+    }
+
+    /// <summary>
+    /// 보드 강제 재배치 직전 선택/하이라이트/애니메이션 상태를 정리합니다.
+    /// </summary>
+    public void CancelCurrentSelectionForBoardTransition()
+    {
+        selectedPiece = null;
+        boardUI?.DeleteSelectTile();
+        boardUI?.DeleteValidMoveTiles();
     }
 
     public void RequestAIMove()

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardAnim.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardAnim.cs
@@ -35,6 +35,9 @@ public class CardAnim : MonoBehaviour
 
     public void EnableCardDataUI()
     {
+        if (CardSelectionState.IsLocked)
+            return;
+
         SoundManager.Instance.SFXPlay("CardClickSFX", clickSFX);
         ClickOnAnimation();
         panel.SetCardData(this);

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
@@ -25,13 +25,16 @@ public class CardDescPanel : ButtonPanel
     [SerializeField] private TMP_Text subDescPieceContent;
     // 규칙 타입
     [SerializeField] private TMP_Text subDescContent;
+    [SerializeField] private SubDescFoldController subDescFoldController;
 
     private CardAnim selectedCard;
+    private Sprite subDescDefaultIconSprite;
 
     protected override void Awake()
     {
         base.Awake();
         TryAutoBindTierUI();
+        CacheSubDescDefaultIcon();
     }
 
     public override void DisablePanel()
@@ -107,11 +110,18 @@ public class CardDescPanel : ButtonPanel
         if (data.NeedAdditionalDescription)
         {
             subDesc.SetActive(true);
+            subDescFoldController?.Hide();
+
             if (subDescTitle != null)
+            {
+                subDescTitle.enabled = true;
                 subDescTitle.text = data.AdditionalDescriptionTitle;
+            }
 
             bool isPiece = data.DescriptionType == AdditionalDescription.Piece;
-            if (subDescPieceImage != null) subDescPieceImage.gameObject.SetActive(isPiece);
+            ApplySubDescIcon(data, isPiece);
+            TMP_Text activeSubDescText = isPiece ? subDescPieceContent : subDescContent;
+
             if (subDescMovementImage != null) subDescMovementImage.gameObject.SetActive(isPiece);
             if (subDescPieceContent != null) subDescPieceContent.gameObject.SetActive(isPiece);
             if (subDescContent != null) subDescContent.gameObject.SetActive(!isPiece);
@@ -119,20 +129,34 @@ public class CardDescPanel : ButtonPanel
             if (isPiece)
             {
                 if (subDescPieceImage != null)
-                    subDescPieceImage.sprite = data.PieceDescImage;
+                {
+                    subDescPieceImage.enabled = true;
+                }
                 if (subDescMovementImage != null)
+                {
+                    subDescMovementImage.enabled = true;
                     subDescMovementImage.sprite = data.MovementImage;
+                }
                 if (subDescPieceContent != null)
+                {
+                    subDescPieceContent.enabled = true;
                     subDescPieceContent.text = data.PieceDescContent;
+                }
             }
             else
             {
                 if (subDescContent != null)
+                {
+                    subDescContent.enabled = true;
                     subDescContent.text = data.AdditionalDescriptionContent;
+                }
             }
+
+            subDescFoldController?.Refresh(activeSubDescText);
         }
         else
         {
+            subDescFoldController?.Hide();
             subDesc.SetActive(false);
         }
     }
@@ -227,6 +251,37 @@ public class CardDescPanel : ButtonPanel
             {
                 target.color = color;
             }
+        }
+    }
+
+    private void ApplySubDescIcon(CardDataSO data, bool isPiece)
+    {
+        if (subDescPieceImage == null)
+        {
+            return;
+        }
+
+        subDescPieceImage.gameObject.SetActive(true);
+        subDescPieceImage.enabled = true;
+
+        Sprite iconSprite = isPiece ? data.PieceDescImage : subDescDefaultIconSprite;
+        if (iconSprite != null)
+        {
+            subDescPieceImage.sprite = iconSprite;
+            return;
+        }
+
+        if (subDescDefaultIconSprite != null)
+        {
+            subDescPieceImage.sprite = subDescDefaultIconSprite;
+        }
+    }
+
+    private void CacheSubDescDefaultIcon()
+    {
+        if (subDescPieceImage != null && subDescDefaultIconSprite == null)
+        {
+            subDescDefaultIconSprite = subDescPieceImage.sprite;
         }
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/SubDescFoldController.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/SubDescFoldController.cs
@@ -1,0 +1,185 @@
+using TMPro;
+using UnityEngine;
+
+public class SubDescFoldController : MonoBehaviour
+{
+    [SerializeField] private RectTransform subDescRoot;
+    [SerializeField] private RectTransform pushedContentRoot;
+    [SerializeField] private GameObject moreToggle;
+    [SerializeField] private TMP_Text moreToggleIcon;
+    [SerializeField] private TMP_Text pieceDescriptionText;
+    [SerializeField] private TMP_Text ruleDescriptionText;
+    [SerializeField] private float minExpandHeight = 0f;
+    [SerializeField] private float maxExpandHeight = 640f;
+    [SerializeField] private float overflowPadding = 32f;
+
+    private TMP_Text activeText;
+    private Vector2 rootDefaultSize;
+    private Vector2 rootDefaultPosition;
+    private Vector2 pushedContentDefaultPosition;
+    private Vector2 pieceTextDefaultSize;
+    private Vector2 ruleTextDefaultSize;
+    private float currentExpandHeight;
+    private bool isExpanded;
+    private bool hasDefaults;
+
+    private void Awake()
+    {
+        CacheDefaults();
+        ConfigureTextOverflow();
+        HideToggle();
+    }
+
+    public void Refresh(TMP_Text text)
+    {
+        CacheDefaults();
+        ConfigureTextOverflow();
+
+        activeText = text;
+        SetExpanded(false);
+
+        bool shouldShow = IsTextOverflowing(activeText);
+        if (moreToggle != null)
+        {
+            moreToggle.SetActive(shouldShow);
+        }
+
+        currentExpandHeight = shouldShow ? CalculateExpandHeight(activeText) : 0f;
+    }
+
+    public void Hide()
+    {
+        SetExpanded(false);
+        activeText = null;
+        HideToggle();
+    }
+
+    public void Toggle()
+    {
+        SetExpanded(!isExpanded);
+    }
+
+    private void HideToggle()
+    {
+        if (moreToggle != null)
+        {
+            moreToggle.SetActive(false);
+        }
+    }
+
+    private void CacheDefaults()
+    {
+        if (hasDefaults || subDescRoot == null)
+        {
+            return;
+        }
+
+        rootDefaultSize = subDescRoot.sizeDelta;
+        rootDefaultPosition = subDescRoot.anchoredPosition;
+
+        if (pushedContentRoot != null)
+        {
+            pushedContentDefaultPosition = pushedContentRoot.anchoredPosition;
+        }
+
+        if (pieceDescriptionText != null)
+        {
+            pieceTextDefaultSize = pieceDescriptionText.rectTransform.sizeDelta;
+        }
+
+        if (ruleDescriptionText != null)
+        {
+            ruleTextDefaultSize = ruleDescriptionText.rectTransform.sizeDelta;
+        }
+
+        hasDefaults = true;
+    }
+
+    private void ConfigureTextOverflow()
+    {
+        if (pieceDescriptionText != null)
+        {
+            pieceDescriptionText.overflowMode = TextOverflowModes.Ellipsis;
+        }
+
+        if (ruleDescriptionText != null)
+        {
+            ruleDescriptionText.overflowMode = TextOverflowModes.Ellipsis;
+        }
+    }
+
+    private void SetExpanded(bool expanded)
+    {
+        CacheDefaults();
+
+        if (!hasDefaults || subDescRoot == null)
+        {
+            isExpanded = false;
+            return;
+        }
+
+        isExpanded = expanded;
+        float heightDelta = expanded ? currentExpandHeight : 0f;
+
+        subDescRoot.sizeDelta = new Vector2(rootDefaultSize.x, rootDefaultSize.y + heightDelta);
+        subDescRoot.anchoredPosition = rootDefaultPosition;
+        ApplyPushedContentPosition(heightDelta);
+        ApplyTextHeight(heightDelta);
+
+        if (moreToggleIcon != null)
+        {
+            moreToggleIcon.text = "v";
+            moreToggleIcon.rectTransform.localScale = new Vector3(1f, expanded ? -1f : 1f, 1f);
+        }
+    }
+
+    private void ApplyPushedContentPosition(float heightDelta)
+    {
+        if (pushedContentRoot == null)
+        {
+            return;
+        }
+
+        pushedContentRoot.anchoredPosition = pushedContentDefaultPosition + Vector2.down * heightDelta;
+    }
+
+    private void ApplyTextHeight(float heightDelta)
+    {
+        if (pieceDescriptionText != null)
+        {
+            RectTransform rectTransform = pieceDescriptionText.rectTransform;
+            rectTransform.sizeDelta = new Vector2(pieceTextDefaultSize.x, pieceTextDefaultSize.y + heightDelta);
+        }
+
+        if (ruleDescriptionText != null)
+        {
+            RectTransform rectTransform = ruleDescriptionText.rectTransform;
+            rectTransform.sizeDelta = new Vector2(ruleTextDefaultSize.x, ruleTextDefaultSize.y + heightDelta);
+        }
+    }
+
+    private bool IsTextOverflowing(TMP_Text text)
+    {
+        if (text == null || !text.gameObject.activeInHierarchy)
+        {
+            return false;
+        }
+
+        Canvas.ForceUpdateCanvases();
+        text.ForceMeshUpdate();
+
+        float visibleHeight = text.rectTransform.rect.height;
+        return text.isTextOverflowing || text.preferredHeight > visibleHeight + 1f;
+    }
+
+    private float CalculateExpandHeight(TMP_Text text)
+    {
+        if (text == null)
+        {
+            return minExpandHeight;
+        }
+
+        float overflowHeight = Mathf.Max(0f, text.preferredHeight - text.rectTransform.rect.height);
+        return Mathf.Clamp(overflowHeight + overflowPadding, minExpandHeight, maxExpandHeight);
+    }
+}

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/SubDescFoldController.cs.meta
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/SubDescFoldController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12e62f6d7d1f4ed4a86d759c0d5ef4d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요
게임 씬에 UI관련 이슈들을 해결했습니다.

## 해결한 이슈
- #147 
  - 부가 설명에 더보기 기능을 추가해서 부가설명의 패널 크기를 변경하여서 내용을 전부 볼 수 있게 해결
  - 기물/타일 선택중에는 카드 선택이 불가능하도록 수정
- #135 
  - 기물 이동 후에 `BoardManager.Instance.RefreshMoves();`를 호출해서 행마를 즉시 변경 시키는 것으로 해결

그 외에 투기장 전환 시 기물 행마 표기 제거하는 로직을 추가했습니다