### PR TITLE
[Fix] 기물 생성/교체 시 이동 애니메이션 비활성화

### DIFF
--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -386,7 +386,7 @@ public class BoardManager : MonoBehaviour
 
         board[target.x, target.y] = piece;
         Vector3 WorldPos = GridPosToWorldPos(target);
-        piece.Move(target, WorldPos);
+        piece.Move(target, WorldPos, animate: true);
 
         if (isCapture)
             // 잡는 대상의 이벤트 호출
@@ -467,7 +467,7 @@ public class BoardManager : MonoBehaviour
             }
 
             Vector3 WorldPos = GridPosToWorldPos(pos);
-            newPiece.Move(pos, WorldPos);
+            newPiece.Move(pos, WorldPos, animate: false);
 
             Pieces.Add(newPiece);
         }
@@ -892,7 +892,7 @@ public class BoardManager : MonoBehaviour
 
         board[target.x, target.y] = piece;
         Vector3 WorldPos = GridPosToWorldPos(target);
-        piece.Move(target, WorldPos);
+        piece.Move(target, WorldPos, animate: true);
 
         // 프로모션
         if (piece is Pawn)
@@ -935,7 +935,7 @@ public class BoardManager : MonoBehaviour
             Vector3Int target = newPositions[i];
             board[target.x, target.y] = pieces[i];
             Vector3 worldPos = GridPosToWorldPos(target);
-            pieces[i].Move(target, worldPos);
+            pieces[i].Move(target, worldPos, animate: true);
         }
     }
 

--- a/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
@@ -215,7 +215,12 @@ public class Piece : MonoBehaviour
 
     public const float MoveDuration = 0.5f;
 
-    public virtual void Move(Vector3Int target, Vector3 WorldPos, bool animate = false)
+    public virtual void Move(Vector3Int target, Vector3 WorldPos)
+    {
+        Move(target, WorldPos, false);
+    }
+
+    public virtual void Move(Vector3Int target, Vector3 WorldPos, bool animate)
     {
         Pos = target;
 

--- a/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
+++ b/ChaosChess_v2/Assets/Script/Pieces/Piece.cs
@@ -215,7 +215,7 @@ public class Piece : MonoBehaviour
 
     public const float MoveDuration = 0.5f;
 
-    public virtual void Move(Vector3Int target, Vector3 WorldPos, bool animate = true)
+    public virtual void Move(Vector3Int target, Vector3 WorldPos, bool animate = false)
     {
         Pos = target;
 

--- a/ChaosChess_v2/ChaosChess_v2.slnx
+++ b/ChaosChess_v2/ChaosChess_v2.slnx
@@ -1,0 +1,5 @@
+﻿<Solution>
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Assembly-CSharp-firstpass.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
+</Solution>


### PR DESCRIPTION
## 개요
기물 생성/교체 시 이동 애니메이션 비활성화 하도록 로직을 수정했습니다.

## 기타 사항
`Piece`의 `Move` 메서드에서 애니메이션 기본값을 `true`에서 `false`로 수정했습니다.