### PR TITLE
[Fix] 투기장, AI 수 로직 수정

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -810,7 +810,7 @@ GameObject:
   - component: {fileID: 122585168}
   - component: {fileID: 122585167}
   m_Layer: 5
-  m_Name: Image (1)
+  m_Name: inputBlockImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -12342,6 +12342,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c348ec35ec64034fb16e3079b555922, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cardHandLayout: {fileID: 1422633471}
 --- !u!1 &1952912593
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -28,6 +28,8 @@ public class ArenaManager : MonoBehaviour
     private const int MaxPlayerMoveCount = 8;
 
     public static ArenaManager Instance;
+    [SerializeField] private CardHandLayout cardHandLayout;
+
     internal event Action<CardDataSO, int> ArenaStarted;
     internal event Action<int> ArenaRemainingTurnsChanged;
     internal event Action ArenaEnded;
@@ -71,6 +73,7 @@ public class ArenaManager : MonoBehaviour
     {
         if (isArenaActive) return;
         isArenaActive = true;
+        cardHandLayout?.SetArenaInputBlocked(true);
 
         GameManager gm = GameManager.Instance;
         gm.CancelCurrentSelectionForBoardTransition();
@@ -174,6 +177,7 @@ public class ArenaManager : MonoBehaviour
     {
         if (!isArenaActive) return;
         isArenaActive = false;
+        cardHandLayout?.SetArenaInputBlocked(false);
 
         GameManager gm = GameManager.Instance;
         gm.CancelCurrentSelectionForBoardTransition();

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -290,6 +290,12 @@ public class BoardManager : MonoBehaviour
     // uci로 받은 이동을 적용한다
     public void ApplyUCIMove(string uciMove)
     {
+        if (!IsValidUciMove(uciMove))
+        {
+            Debug.LogWarning($"[AI] Invalid UCI move: {uciMove}");
+            return;
+        }
+
         // "e2e4" → from(4,1), to(4,3) 변환
         Vector3Int from = UCIToGrid(uciMove.Substring(0, 2));
         Vector3Int to = UCIToGrid(uciMove.Substring(2, 2));
@@ -314,6 +320,17 @@ public class BoardManager : MonoBehaviour
             MovePiece(piece, to, promotion);
 
         DOVirtual.DelayedCall(Piece.MoveDuration, () => GameManager.Instance.NextTurn());
+    }
+
+    public bool IsValidUciMove(string move)
+    {
+        if (string.IsNullOrEmpty(move) || move == "none" || move.Length < 4)
+            return false;
+
+        return move[0] >= 'a' && move[0] <= 'h'
+            && move[1] >= '1' && move[1] <= '8'
+            && move[2] >= 'a' && move[2] <= 'h'
+            && move[3] >= '1' && move[3] <= '8';
     }
 
     /// <summary>

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -465,6 +465,14 @@ public class GameManager : MonoBehaviour
             }
 
             string randomMove = ChooseRandomLegalMove(moves);
+            if (randomMove == "none")
+            {
+                Debug.LogWarning("[AI] No valid legal moves found after filtering. Ending game.");
+                EvaluateGameState(Array.Empty<string>());
+                ApplyGameResult();
+                return;
+            }
+
             BoardManager.Instance.ApplyUCIMove(randomMove);
         });
     }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
-using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
+    private const int AiMoveTimeMs = 5000;
+
     public GameResult FinishType { get; set; } = GameResult.None;
 
     public static GameManager Instance;
@@ -437,13 +438,53 @@ public class GameManager : MonoBehaviour
 
         FairyStockfishBridge.Instance.GetBestMoveAsync(
             depth: 12,
-            moveTimeMs: 2000,
+            moveTimeMs: AiMoveTimeMs,
             callback: (uciMove) =>
             {
-                // UCI 수 (예: "e2e4") → Vector3Int 변환 후 BoardManager에 적용
-                BoardManager.Instance.ApplyUCIMove(uciMove);
+                if (BoardManager.Instance.IsValidUciMove(uciMove))
+                {
+                    BoardManager.Instance.ApplyUCIMove(uciMove);
+                    return;
+                }
+
+                Debug.LogWarning($"[AI] Stockfish returned invalid move '{uciMove}'. Using random legal fallback.");
+                ApplyFallbackLegalAIMove();
             }
         );
+    }
+
+    private void ApplyFallbackLegalAIMove()
+    {
+        FairyStockfishBridge.Instance.GetLegalMovesAsync(moves =>
+        {
+            if (moves == null || moves.Length == 0)
+            {
+                EvaluateGameState(Array.Empty<string>());
+                ApplyGameResult();
+                return;
+            }
+
+            string randomMove = ChooseRandomLegalMove(moves);
+            BoardManager.Instance.ApplyUCIMove(randomMove);
+        });
+    }
+
+    private string ChooseRandomLegalMove(string[] moves)
+    {
+        List<string> validMoves = new List<string>();
+
+        foreach (string move in moves)
+        {
+            if (!BoardManager.Instance.IsValidUciMove(move))
+                continue;
+
+            validMoves.Add(move);
+        }
+
+        if (validMoves.Count == 0)
+            return "none";
+
+        return validMoves[UnityEngine.Random.Range(0, validMoves.Count)];
     }
 
     private void EvaluateGameState(string[] moves)

--- a/ChaosChess_v2/Assets/Script/FairyStockfishBridge.cs
+++ b/ChaosChess_v2/Assets/Script/FairyStockfishBridge.cs
@@ -157,6 +157,11 @@ public class FairyStockfishBridge : MonoBehaviour
 
         Thread thread = new Thread(() =>
         {
+            lock (_queueLock)
+            {
+                _outputQueue.Clear();
+            }
+
             SendCommand(command);
             int timeoutMs = moveTimeMs > 0 ? Mathf.Max(moveTimeMs + 1000, 3000) : 10000;
             string bestMove = WaitForBestMove(timeoutMs);

--- a/ChaosChess_v2/Assets/Script/FairyStockfishBridge.cs
+++ b/ChaosChess_v2/Assets/Script/FairyStockfishBridge.cs
@@ -158,7 +158,8 @@ public class FairyStockfishBridge : MonoBehaviour
         Thread thread = new Thread(() =>
         {
             SendCommand(command);
-            string bestMove = WaitForBestMove();
+            int timeoutMs = moveTimeMs > 0 ? Mathf.Max(moveTimeMs + 1000, 3000) : 10000;
+            string bestMove = WaitForBestMove(timeoutMs);
             _isThinking = false;
             UnityMainThreadDispatcher.Instance().Enqueue(() =>
             {
@@ -451,6 +452,26 @@ public class FairyStockfishBridge : MonoBehaviour
             }
             Thread.Sleep(10);
         }
+
+        SendCommand("stop");
+        timeout = DateTime.Now.AddMilliseconds(1000);
+        while (DateTime.Now < timeout)
+        {
+            lock (_queueLock)
+            {
+                while (_outputQueue.Count > 0)
+                {
+                    string line = _outputQueue.Dequeue();
+                    if (line.StartsWith("bestmove"))
+                    {
+                        string[] parts = line.Split(' ');
+                        return parts.Length > 1 ? parts[1] : "none";
+                    }
+                }
+            }
+            Thread.Sleep(10);
+        }
+
         return "none";
     }
 #endif

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
@@ -49,6 +49,8 @@ public class CardHandLayout : MonoBehaviour
 
     public void RefreshAnimated() => Refresh(animate: true);
 
+    public void SetArenaInputBlocked(bool isBlocked) => SetInputBlocked(isBlocked);
+
     private void SetInputBlocked(bool isBlocked)
     {
         if (inputBlockPanel == null)


### PR DESCRIPTION
## 개요
투기장 내 카드 사용을 막는 로직을 추가했습니다.

또한 AI가 수를 오래 고민할 때 Stockfish 브릿지에서 반환될 수 있는 `"none"` 값을 UCI 수로 처리하던 문제를 수정했습니다.
이제 유효하지 않은 UCI 값은 보드에 적용하지 않고, fallback으로 합법수 중 하나를 선택합니다.

## 기타 사항
현재 AI 수 선택 흐름은 다음과 같습니다.

```
1. Stockfish에게 depth 12 기준으로 수를 찾게 함
2. 정해진 시간 안에 bestmove가 나오면 그 수를 둠
3. 시간이 지나도 bestmove가 안 나오면 stop을 보내서 계산을 중단시킴
4. Stockfish가 중단 시점까지 찾은 bestmove를 반환하면 그 수를 둠
5. 그래도 none/invalid 값이면 랜덤 합법수로 대체함
```
none/invalid 값은 "none", 빈 값, e2e4처럼 출발/도착 칸을 가진 UCI 형식이 아닌 값을 의미함