### PR TITLE
[Feature] 맵 이동 카드 중 카드 지급 턴 카운트 정지 기능 구현

### DIFF
--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -76,6 +76,7 @@ public class ArenaManager : MonoBehaviour
         cardHandLayout?.SetArenaInputBlocked(true);
 
         GameManager gm = GameManager.Instance;
+        gm.PushCardIntervalPause();
         gm.CancelCurrentSelectionForBoardTransition();
 
         opponentArenaPieces = opponents;
@@ -180,6 +181,7 @@ public class ArenaManager : MonoBehaviour
         cardHandLayout?.SetArenaInputBlocked(false);
 
         GameManager gm = GameManager.Instance;
+        gm.PopCardIntervalPause();
         gm.CancelCurrentSelectionForBoardTransition();
 
         // 이벤트 구독 해제 및 투기장 모드 비활성화

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -24,10 +24,12 @@ public class GameManager : MonoBehaviour
     public bool IsGameInput = true;
     public bool IsEndGame { get; private set; } = false;
     public bool IsArenaMode { get; set; } = false;
+    public bool IsCardIntervalPaused => cardIntervalPauseCount > 0;
     private List<(int turn, Action action)> recievedActions = new List<(int, Action)>();
     // 투기장 진행 중 기존 예약 액션(폭탄, 지속효과 해제 등) 소모를 잠시 멈춥니다.
     private bool areQueuedActionsPaused = false;
     private int queuedActionPauseTurn = -1;
+    private int cardIntervalPauseCount = 0;
 
     /// <summary>플레이어 턴이 시작되고 CanMovePos가 유효해진 직후 발행됩니다.</summary>
     public event Action OnPlayerTurnStarted;
@@ -339,6 +341,19 @@ public class GameManager : MonoBehaviour
         areQueuedActionsPaused = false;
         queuedActionPauseTurn = -1;
     }
+
+    /// <summary>카드 지급 주기 카운트를 일시 정지합니다.</summary>
+    public void PushCardIntervalPause()
+    {
+        cardIntervalPauseCount++;
+    }
+
+    /// <summary>카드 지급 주기 카운트 일시 정지를 해제합니다.</summary>
+    public void PopCardIntervalPause()
+    {
+        cardIntervalPauseCount = Mathf.Max(0, cardIntervalPauseCount - 1);
+    }
+
     // MoveSelected 안에서 플레이어 수 적용 후:
     private void MoveSelected(Vector3Int target)
     {

--- a/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
@@ -46,6 +46,8 @@ public class Player : MonoBehaviour
 
     private void HandlePlayerTurnStarted()
     {
+        if (GameManager.Instance.IsCardIntervalPaused) return;
+
         _playerTurnCount++;
         if (_playerTurnCount < _cardInterval || cardRandomizer.CurrentCardCnt >= _maxCardCount) return;
         _playerTurnCount = 0;


### PR DESCRIPTION
## 개요
맵 이동 카드 중 카드 지급 턴 카운트 정지 기능 구현하기 위해 `GameManager`에 카운터 기반 플래그 `IsCardIntervalPaused`를 추가.
투기장 들어가고 나갈때 값을 +-1 하도록 구현했습니다.

## 기타 사항
현재 맵 이동 계열 카드는 투기장밖에 없지만, 추후 유사한 맵 이동 카드가 추가될 수도 있기 때문에,
단순 bool 대신 카운터 기반 플래그로 처리해, 여러 효과가 중첩되었을 때 카드 지급 카운트가 잘못 재개되지 않도록 했습니다.