### PR TITLE
[Fix] 행마 오버라이드 효과 충돌 방지

### DIFF
--- a/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
+++ b/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
@@ -30,7 +30,6 @@ public class CardDataSOEditor : Editor
     SerializedProperty targetColor;
     SerializedProperty hasLimit;
     SerializedProperty limitTurn;
-    SerializedProperty showStatusCard;
     SerializedProperty statusDisplayType;
 
     // 부가 정보
@@ -75,7 +74,6 @@ public class CardDataSOEditor : Editor
         targetColor = serializedObject.FindProperty("GlobalTargetColor");
         hasLimit = serializedObject.FindProperty("HasLimit");
         limitTurn = serializedObject.FindProperty("LimitTurn");
-        showStatusCard = serializedObject.FindProperty("ShowStatusCard");
         statusDisplayType = serializedObject.FindProperty("StatusDisplayType");
 
         needAdditionalDescription = serializedObject.FindProperty("NeedAdditionalDescription");

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -61,8 +61,6 @@ public class CardDataSO : ScriptableObject
     public PieceColor GlobalTargetColor;
     public bool HasLimit;
     public int LimitTurn;
-    [Tooltip("활성화 시 전역 상태 카드 UI를 표시합니다.")]
-    public bool ShowStatusCard;
     [Tooltip("상태 카드에 표시할 문구 타입입니다.")]
     public ActiveEffectStatusType StatusDisplayType = ActiveEffectStatusType.Active;
 

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -196,6 +196,8 @@ public abstract class Effector : MonoBehaviour, IEffect
 /// <summary>기물에 부착되는 효과의 기반 추상 클래스</summary>
 public abstract class PieceEffector : Effector, IPieceEffect
 {
+    private static readonly List<PieceEffector> effectorBuffer = new();
+
     protected Piece target;
 
     public static bool HasActiveMovementOverride(Piece piece)
@@ -203,12 +205,18 @@ public abstract class PieceEffector : Effector, IPieceEffect
         if (piece == null) return false;
         if (piece.MoveFenOverride != null || piece.FenOverride != null) return true;
 
-        foreach (PieceEffector effector in piece.GetComponents<PieceEffector>())
+        effectorBuffer.Clear();
+        piece.GetComponents(effectorBuffer);
+        foreach (PieceEffector effector in effectorBuffer)
         {
             if (effector is IMovementOverrideEffect && !effector.IsSuspended)
+            {
+                effectorBuffer.Clear();
                 return true;
+            }
         }
 
+        effectorBuffer.Clear();
         return false;
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 /// <summary>투기장 진입 시에도 일시정지하지 않고 유지할 효과 마커입니다.</summary>
 public interface IArenaPersistentEffect { }
 
+/// <summary>기물의 행마/표현 override를 점유하는 효과 마커입니다.</summary>
+public interface IMovementOverrideEffect { }
+
 /// <summary>기물 또는 타일에 효과를 적용하고 관리하는 추상 컴포넌트</summary>
 public abstract class Effector : MonoBehaviour, IEffect
 {
@@ -194,6 +197,20 @@ public abstract class Effector : MonoBehaviour, IEffect
 public abstract class PieceEffector : Effector, IPieceEffect
 {
     protected Piece target;
+
+    public static bool HasActiveMovementOverride(Piece piece)
+    {
+        if (piece == null) return false;
+        if (piece.MoveFenOverride != null || piece.FenOverride != null) return true;
+
+        foreach (PieceEffector effector in piece.GetComponents<PieceEffector>())
+        {
+            if (effector is IMovementOverrideEffect && !effector.IsSuspended)
+                return true;
+        }
+
+        return false;
+    }
 
     public void Init(Piece piece, int duration = -1)
     {

--- a/ChaosChess_v2/Assets/Script/Card/Selector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector.cs
@@ -13,6 +13,7 @@ public static class CardSelectionState
 {
     private static CardSelectionOwner currentSelectionOwner = CardSelectionOwner.None;
     public static bool IsLocked => currentSelectionOwner != CardSelectionOwner.None;
+    public static CardSelectionOwner CurrentOwner => currentSelectionOwner;
 
     public static void Lock(CardSelectionOwner owner)
     {

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -109,7 +109,8 @@ public class PieceSelector : Selector<Piece>
         
         CardRandomizerManager.Instance?.ExecuteCard(cardData.DataSO, () => skillCard.Execute(args));
 
-        if(cardData != null)
+        bool switchedSelector = CardSelectionState.CurrentOwner != CardSelectionOwner.Piece;
+        if(cardData != null && !switchedSelector)
             cardRandomizer?.RemoveCard(cardData.gameObject);
 
         DisableSelector();
@@ -193,6 +194,9 @@ public class PieceSelector : Selector<Piece>
     /// <summary>해당 기물에 일시정지되지 않은 PieceEffector가 하나라도 있는지 확인합니다.</summary>
     private bool HasActivePieceEffector(Piece piece)
     {
+        if (PieceEffector.HasActiveMovementOverride(piece))
+            return true;
+
         pieceEffectorBuffer.Clear();
         piece.GetComponents(pieceEffectorBuffer);
         foreach (PieceEffector effector in pieceEffectorBuffer)

--- a/ChaosChess_v2/Assets/Script/Card/Skills/CaterpillarCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/CaterpillarCard.cs
@@ -26,7 +26,7 @@ public class CaterpillarCard : CardData, IPieceCard
     }
 }
 
-public class CaterpillarEffector : PieceEffector
+public class CaterpillarEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -36,7 +36,8 @@ public class CaterpillarEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.FenOverride = null;
+        if (target.FenOverride?.ToLower() == "z")
+            target.FenOverride = null;
         RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/Skills/CaterpillarCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/CaterpillarCard.cs
@@ -36,7 +36,7 @@ public class CaterpillarEffector : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.FenOverride?.ToLower() == "z")
+        if (target != null && target.FenOverride?.ToLower() == "z")
             target.FenOverride = null;
         RefreshMoves();
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/Skills/MutinyCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/MutinyCard.cs
@@ -39,7 +39,7 @@ public class MutinyEffect : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "w")
+        if (target != null && target.MoveFenOverride?.ToLower() == "w")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/Skills/MutinyCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/MutinyCard.cs
@@ -20,13 +20,16 @@ public class MutinyCard : CardData, ICard
 
         foreach(Queen p in queens)
         {
+            if (PieceEffector.HasActiveMovementOverride(p))
+                continue;
+
             MutinyEffect effect = CreatePieceEffector<MutinyEffect>(p);
             effect.Apply();
         }
     }
 }
 
-public class MutinyEffect : PieceEffector
+public class MutinyEffect : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -36,7 +39,8 @@ public class MutinyEffect : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "w")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
@@ -38,7 +38,7 @@ public class AgileEffect : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "u")
+        if (target != null && target.MoveFenOverride?.ToLower() == "u")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
@@ -28,7 +28,7 @@ public class AgileCard : CardData, IPieceCard
     }
 }
 
-public class AgileEffect : PieceEffector
+public class AgileEffect : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -38,7 +38,8 @@ public class AgileEffect : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "u")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/AimCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/AimCard.cs
@@ -18,7 +18,8 @@ public class AimCard : CardData, IPieceCard
     }
     public void ResetMoveFen(Piece piece)
     {
-        piece.MoveFenOverride = null;
+        if (piece != null && piece.MoveFenOverride?.ToLower() == "t")
+            piece.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
     }
 
@@ -31,7 +32,7 @@ public class AimCard : CardData, IPieceCard
     }
 }
 
-public class AimEffector : PieceEffector
+public class AimEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -41,7 +42,8 @@ public class AimEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "t")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/AimCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/AimCard.cs
@@ -42,7 +42,7 @@ public class AimEffector : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "t")
+        if (target != null && target.MoveFenOverride?.ToLower() == "t")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -28,16 +28,8 @@ public class CobwebCard : CardData, ITileCard
 
         CobwebEffector effect = CreateGlobalEffector<CobwebEffector>();
         effect.TilePos = pos;
-        effect.cobwebCard = this;
         effect.DataSO = DataSO;
         effect.Apply();
-    }
-
-    public void OnStuckWrap(Piece piece)
-    {
-        CobwebPieceEffector pieceEffect = piece.gameObject.AddComponent<CobwebPieceEffector>();
-        pieceEffect.Init(piece, DataSO.LimitTurn);
-        pieceEffect.Apply();
     }
 }
 
@@ -48,7 +40,6 @@ public class CobwebEffector : GlobalEffector
     private bool isTriggered = false;
 
     public Vector3Int TilePos;
-    public CobwebCard cobwebCard;
 
     protected override void OnApply()
     {
@@ -82,9 +73,12 @@ public class CobwebEffector : GlobalEffector
             cur += dir;
             if (cur == TilePos)
             {
+                if (PieceEffector.HasActiveMovementOverride(piece))
+                    return true;
+
                 isTriggered = true;
                 BoardManager.Instance.ForceTeleport(piece, TilePos, '\0', false);
-                cobwebCard.OnStuckWrap(piece);
+                ApplyStuckEffect(piece);
                 BoardManager.Instance.RefreshMoves();
                 Revert();
                 return false;
@@ -138,13 +132,23 @@ public class CobwebEffector : GlobalEffector
         return Vector3Int.zero;
     }
 
+    private void ApplyStuckEffect(Piece piece)
+    {
+        if (piece == null) return;
+
+        CobwebPieceEffector pieceEffect = piece.gameObject.AddComponent<CobwebPieceEffector>();
+        pieceEffect.CardSO = null;
+        pieceEffect.Init(piece, DataSO.LimitTurn);
+        pieceEffect.Apply();
+    }
+
     protected override IEnumerable<Vector3Int> GetVisualPositions()
     {
         yield return TilePos;
     }
 }
 
-public class CobwebPieceEffector : PieceEffector
+public class CobwebPieceEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -154,7 +158,8 @@ public class CobwebPieceEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "a")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -158,7 +158,7 @@ public class CobwebPieceEffector : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "a")
+        if (target != null && target.MoveFenOverride?.ToLower() == "a")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ConcentrationCard.cs
@@ -3,7 +3,7 @@
 /// 정신 집중 - 기물 전용 (전설, 아마존)
 /// 선택 기물은 일정 수치 동안 상호작용할 수 없고, 이후 아마존으로 승격됩니다.
 /// </summary>
-class ConcentrationEffector : PieceEffector
+class ConcentrationEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {

--- a/ChaosChess_v2/Assets/Script/Card/skills/DarkHandCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/DarkHandCard.cs
@@ -28,7 +28,7 @@ public class DarkHandCard : CardData, IPieceCard
     }
 }
 
-public class DarkHandEffector : PieceEffector
+public class DarkHandEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -38,7 +38,8 @@ public class DarkHandEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        if (target != null) target.FenOverride = null;
+        if (target != null && target.FenOverride?.ToLower() == "a")
+            target.FenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
@@ -26,7 +26,7 @@ public class FastMarchCard : CardData, IPieceCard
     }
 }
 
-public class FastMarchCardEffector : PieceEffector
+public class FastMarchCardEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -36,7 +36,8 @@ public class FastMarchCardEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "f")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/FastMarchCard.cs
@@ -36,7 +36,7 @@ public class FastMarchCardEffector : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "f")
+        if (target != null && target.MoveFenOverride?.ToLower() == "f")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/FatherEnemyCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/FatherEnemyCard.cs
@@ -29,15 +29,12 @@ public class FatherEnemyCard : CardData, IPieceCard
     public void Create(Piece piece)
     {
         var effector = CreatePieceEffector<FatherEnemyEffector>(piece);
-        effector.fatherEnemyCard = this;
         effector.Apply();
     }
 }
 
 public class FatherEnemyEffector : PieceEffector
 {
-    public FatherEnemyCard fatherEnemyCard;
-
     private void OnPieceSelected(Piece piece)
     {
         if (piece != target) return;
@@ -99,9 +96,19 @@ public class FatherEnemyEffector : PieceEffector
         else
         {
             Revert();
-            fatherEnemyCard.Create(target);
+            ApplyAwakening(target);
         }
 
+    }
+
+    private void ApplyAwakening(Piece piece)
+    {
+        if (piece == null) return;
+
+        var effector = piece.gameObject.AddComponent<FatherEnemyEffector>();
+        effector.CardSO = CardSO;
+        effector.Init(piece, CardSO != null ? CardSO.PieceLimitTurn : RemainingTurns);
+        effector.Apply();
     }
 
     private void FinishAwakening()

--- a/ChaosChess_v2/Assets/Script/Card/skills/GiantCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/GiantCard.cs
@@ -77,7 +77,7 @@ public class GiantStunEffector : PieceEffector, IMovementOverrideEffect
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "a")
+        if (target != null && target.MoveFenOverride?.ToLower() == "a")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/GiantCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/GiantCard.cs
@@ -47,7 +47,11 @@ public class GiantEffector : PieceEffector
                 Piece target = BoardManager.Instance.GetPiece(pos);
                 if (target != null)
                 {
+                    if (PieceEffector.HasActiveMovementOverride(target))
+                        continue;
+
                     GiantStunEffector stun = target.gameObject.AddComponent<GiantStunEffector>();
+                    stun.CardSO = null;
                     stun.Init(target, 1);
                     stun.Apply();
                 }
@@ -63,7 +67,7 @@ public class GiantEffector : PieceEffector
 
 }
 
-public class GiantStunEffector : PieceEffector
+public class GiantStunEffector : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -73,7 +77,8 @@ public class GiantStunEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "a")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
@@ -40,6 +40,7 @@ public class LimitlessCard : CardData, IPieceCard
         Vector3Int pos = center.Pos;
 
         var controller = new LimitlessFieldController(pieceEff);
+        pieceEff.SetController(controller);
 
         for (int dx = -1; dx <= 1; dx++)
         {
@@ -64,8 +65,15 @@ public class LimitlessCard : CardData, IPieceCard
     }
 }
 
-public class LimitlessPieceEffector : PieceEffector
+public class LimitlessPieceEffector : PieceEffector, IMovementOverrideEffect
 {
+    private LimitlessFieldController controller;
+
+    public void SetController(LimitlessFieldController controller)
+    {
+        this.controller = controller;
+    }
+
     protected override void OnApply()
     {
         target.FenOverride = "a";
@@ -74,9 +82,20 @@ public class LimitlessPieceEffector : PieceEffector
 
     protected override void OnRevert()
     {
-        target.FenOverride = null;
+        if (target != null && target.FenOverride?.ToLower() == "a")
+            target.FenOverride = null;
+
+        if (controller != null && !controller.IsBroken)
+            controller.Break(skipPieceEffector: true);
+
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
+    }
+
+    public override void OnPieceCaptured()
+    {
+        if (controller != null && !controller.IsBroken)
+            controller.Break(skipPieceEffector: true);
     }
 }
 
@@ -89,13 +108,14 @@ public class LimitlessFieldController
     private LimitlessPieceEffector pieceEff;
 
     private bool broken = false;
+    public bool IsBroken => broken;
 
     public LimitlessFieldController(LimitlessPieceEffector pieceEff)
     {
         this.pieceEff = pieceEff;
     }
 
-    public void Break()
+    public void Break(bool skipPieceEffector = false)
     {
         if (broken) return;
         broken = true;
@@ -109,7 +129,7 @@ public class LimitlessFieldController
         tiles.Clear();
 
         // 2. 기물 효과 제거
-        if (pieceEff != null)
+        if (!skipPieceEffector && pieceEff != null)
             pieceEff.Revert();
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
@@ -83,7 +83,7 @@ public class PsilocybinMushroomPieceEffect : PieceEffector, IMovementOverrideEff
 
     protected override void OnRevert()
     {
-        if (target.MoveFenOverride?.ToLower() == "w")
+        if (target != null && target.MoveFenOverride?.ToLower() == "w")
             target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
@@ -27,17 +27,6 @@ public class PsilocybinMushroomCard : CardData, ITileCard
 
         effect.DataSO = DataSO;
 
-        effect.SetOwner(this);
-        effect.Apply();
-    }
-
-    public void ApplyPieceEffect(Piece piece)
-    {
-        if (piece == null) return;
-
-        var effect = CreatePieceEffector<PsilocybinMushroomPieceEffect>(piece);
-        effect.CardSO = null;
-        effect.Init(piece, 3);
         effect.Apply();
     }
 }
@@ -45,13 +34,6 @@ public class PsilocybinMushroomCard : CardData, ITileCard
 public class PsilocybinMushroomTileEffect : TileEffector
 {
     public CardDataSO DataSO;
-
-    private PsilocybinMushroomCard owner;
-
-    public void SetOwner(PsilocybinMushroomCard card)
-    {
-        owner = card;
-    }
 
     protected override void OnApply()
     {
@@ -79,15 +61,19 @@ public class PsilocybinMushroomTileEffect : TileEffector
 
     public override void OnPieceEnter(Piece piece)
     {
-        if (piece == null || owner == null) return;
+        if (piece == null) return;
+        if (PieceEffector.HasActiveMovementOverride(piece)) return;
 
-        owner.ApplyPieceEffect(piece);
+        var effect = piece.gameObject.AddComponent<PsilocybinMushroomPieceEffect>();
+        effect.CardSO = null;
+        effect.Init(piece, 3);
+        effect.Apply();
 
         Revert();
     }
 }
 
-public class PsilocybinMushroomPieceEffect : PieceEffector
+public class PsilocybinMushroomPieceEffect : PieceEffector, IMovementOverrideEffect
 {
     protected override void OnApply()
     {
@@ -97,7 +83,8 @@ public class PsilocybinMushroomPieceEffect : PieceEffector
 
     protected override void OnRevert()
     {
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "w")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/SneakPawnCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/SneakPawnCard.cs
@@ -20,6 +20,8 @@ public class SneakPawnCard : CardData, IPieceCard
     public void Execute(CardEffectArgs args = null)
     {
         Piece piece = args.Targets[0];
+        if (PieceEffector.HasActiveMovementOverride(piece)) return;
+
         piece.MoveFenOverride = "e";
         BoardManager.Instance.RefreshMoves();
 
@@ -30,6 +32,11 @@ public class SneakPawnCard : CardData, IPieceCard
     }
     public void ResetMoveFen(Piece piece)
     {
+        if (piece == null) return;
+
+        string p = piece.MoveFenOverride?.ToLower();
+        if (p != "e") return;
+
         piece.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/ThunderclapFlashCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ThunderclapFlashCard.cs
@@ -29,7 +29,7 @@ public class ThunderclapFlashCard : CardData, IPieceCard
     }
 }
 
-public class ThunderclapFlashEffector : PieceEffector
+public class ThunderclapFlashEffector : PieceEffector, IMovementOverrideEffect
 {
     public Vector3Int targetPos;
     
@@ -59,7 +59,8 @@ public class ThunderclapFlashEffector : PieceEffector
             BoardManager.Instance.DestroyPiece(pos);
         }
 
-        target.MoveFenOverride = null;
+        if (target.MoveFenOverride?.ToLower() == "m")
+            target.MoveFenOverride = null;
         BoardManager.Instance.RefreshMoves();
 
         Destroy(this);

--- a/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
@@ -11,30 +11,41 @@ public class WindmillCard : CardData, ICard
     {
         var effector = CreateGlobalEffector<WindmillEffector>();
         effector.Init(DataSO.PieceType, ApplyType.All, DataSO.PieceLimitTurn);
-
-        foreach (Piece piece in BoardManager.Instance.GetAllPieces())
-        {
-            piece.MoveFenOverride = piece.Type == PieceType.Rook ? "b" : piece.Type == PieceType.Bishop ? "r" : null;
-        }
-
         effector.Apply();
 
     }
 }
 public class WindmillEffector : GlobalEffector
 {
+    private readonly List<Piece> changed = new();
+
     protected override void OnApply()
     {
+        foreach (Piece piece in BoardManager.Instance.GetAllPieces())
+        {
+            if (PieceEffector.HasActiveMovementOverride(piece))
+                continue;
+
+            string overrideFen = piece.Type == PieceType.Rook ? "b" : piece.Type == PieceType.Bishop ? "r" : null;
+            if (overrideFen == null)
+                continue;
+
+            piece.MoveFenOverride = overrideFen;
+            changed.Add(piece);
+        }
+
         BoardManager.Instance.RefreshMoves();
     }
 
     protected override void OnRevert()
     {
-        foreach (Piece piece in BoardManager.Instance.GetAllPieces())
+        foreach (Piece piece in changed)
         {
-            if (piece.Type == PieceType.Bishop || piece.Type == PieceType.Rook)
+            string p = piece != null ? piece.MoveFenOverride?.ToLower() : null;
+            if (p == "b" || p == "r")
                 piece.MoveFenOverride = null;
         }
+        changed.Clear();
         BoardManager.Instance.RefreshMoves();
         Destroy(this);
     }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -96,7 +96,7 @@ public class ActiveEffectCardDisplay : MonoBehaviour
     private void HandleEffectApplied(Effector effector)
     {
         CardDataSO cardSO = effector.CardSO;
-        if (cardSO == null || !cardSO.ShowStatusCard) return;
+        if (cardSO == null) return;
 
         if (!cards.TryGetValue(cardSO, out ActiveEffectCard card))
         {


### PR DESCRIPTION
## 개요

기물의 `MoveFenOverride` / `FenOverride`가 단일 값으로 관리되면서 여러 행마 변경 효과가 같은 기물에 중첩될 경우, 기존 효과가 덮어씌워지거나 효과 종료 시 다른 효과까지 제거될 수 있는 문제가 있었습니다.

이를 방지하기 위해 행마 override 효과 여부를 공통으로 판정하는 로직을 추가하고, 기물 선택 카드뿐 아니라 타일/전역 효과로 자동 발동되는 행마 변경 효과에도 동일한 중복 방지 정책을 적용했습니다.

또한 일부 장기 지속 Effector가 카드 오브젝트 제거 후 카드 컴포넌트를 참조하던 구조를 정리하고, 텔레포트/무하한처럼 별도 생명주기 처리가 필요한 카드 흐름을 보강했습니다.

## 작업 내용

- 행마/상태 override 효과 중복 적용을 막기 위한 공통 판정을 추가했습니다.
  - `MoveFenOverride`
  - `FenOverride`
  - `IMovementOverrideEffect` 기반 활성 효과

- 이미 행마 override 효과가 적용된 기물에는 추가 행마 변경 효과가 적용되지 않도록 수정했습니다.
  - 기물 선택 카드
  - 환각 버섯
  - 거미줄
  - 거대화 스턴
  - 하극상
  - 풍차
  - 암습의 폰

- override 효과 종료 시 무조건 `null`로 초기화하지 않고, 자신이 설정한 값일 때만 해제하도록 수정했습니다.

- 카드 오브젝트가 제거된 뒤 Effector가 카드 컴포넌트를 참조해 null이 되는 구조를 정리했습니다.
  - 환각 버섯
  - 거미줄
  - 아버지의 원수

- 텔레포트처럼 선택 단계가 이어지는 카드에서 1단계 선택 후 카드가 먼저 제거되지 않도록 보강했습니다.

- 무하한 효과가 종료되거나 중심 기물이 제거될 때 3x3 타일 필드도 함께 정리되도록 수정했습니다.

## 해결한 문제

- 여러 카드가 같은 기물의 `MoveFenOverride` / `FenOverride`를 덮어쓰는 문제
- 효과 종료 시 다른 효과가 설정한 override까지 제거될 수 있는 문제
- 실제 적용 효과와 카드 active 상태가 어긋날 수 있는 문제
- 카드 제거 후 남은 Effector가 카드 컴포넌트를 참조하면서 null 처리되는 문제