### PR TITLE
[Fix] 씬 전환 시 BGM 페이드 전환 미동작 수정

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -3949,8 +3949,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   bgmSource: {fileID: 507959204}
-  titleBgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
-  battleBgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
+  sceneBgmMappings:
+  - sceneName: MainScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: MapScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: RewardScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: ResultScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: MainGameScene
+    bgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
   sceneBgmFadeDuration: 0.8
 --- !u!82 &507959204
 AudioSource:

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -3949,6 +3949,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   bgmSource: {fileID: 507959204}
+  titleBgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  battleBgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
+  sceneBgmFadeDuration: 0.8
 --- !u!82 &507959204
 AudioSource:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -15206,8 +15206,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   bgmSource: {fileID: 1786719295}
-  titleBgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
-  battleBgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
+  sceneBgmMappings:
+  - sceneName: MainScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: MapScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: RewardScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: ResultScene
+    bgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  - sceneName: MainGameScene
+    bgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
   sceneBgmFadeDuration: 0.8
 --- !u!82 &1786719295
 AudioSource:

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -15206,6 +15206,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   bgmSource: {fileID: 1786719295}
+  titleBgmClip: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
+  battleBgmClip: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
+  sceneBgmFadeDuration: 0.8
 --- !u!82 &1786719295
 AudioSource:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/SoundManager.cs
+++ b/ChaosChess_v2/Assets/Script/SoundManager.cs
@@ -1,14 +1,22 @@
 ﻿using System.Collections;
+using DG.Tweening;
 using UnityEngine;
 using UnityEngine.Audio;
 
 
 public class SoundManager : MonoBehaviour
 {
+    private const float DefaultSceneBgmFadeDuration = 0.8f;
     private static SoundManager instance;
 
     public AudioMixer audioMixer;
     [SerializeField] private AudioSource bgmSource;
+    [SerializeField] private AudioClip titleBgmClip;
+    [SerializeField] private AudioClip battleBgmClip;
+    [SerializeField] private float sceneBgmFadeDuration = 0.8f;
+
+    private Tween bgmFadeTween;
+    private float SceneBgmFadeDuration => sceneBgmFadeDuration > 0f ? sceneBgmFadeDuration : DefaultSceneBgmFadeDuration;
 
     public static SoundManager Instance => instance;
     private void Awake()
@@ -20,6 +28,14 @@ public class SoundManager : MonoBehaviour
         }
         else
         {
+            AudioClip sceneBgmClip = bgmSource != null ? bgmSource.clip : null;
+            bgmSource?.Stop();
+
+            if (sceneBgmClip != null)
+            {
+                instance.SwitchBGM(sceneBgmClip, instance.SceneBgmFadeDuration, false);
+            }
+
             Destroy(gameObject);
         }
     }
@@ -51,13 +67,22 @@ public class SoundManager : MonoBehaviour
 
     public void PlayBGM(AudioClip clip, bool loop = true)
     {
+        if (bgmSource == null || clip == null)
+            return;
+
+        bgmFadeTween?.Kill();
         bgmSource.clip = clip;
         bgmSource.loop = loop;
+        bgmSource.volume = 1f;
         bgmSource.Play();
     }
 
     public void StopBGM()
     {
+        if (bgmSource == null)
+            return;
+
+        bgmFadeTween?.Kill();
         bgmSource.Stop();
     }
 
@@ -76,35 +101,100 @@ public class SoundManager : MonoBehaviour
     /// </summary>
     public void SwitchBGM(AudioClip newClip, float duration = 0.8f)
     {
-        StartCoroutine(SwitchBGMCoroutine(newClip, duration));
+        SwitchBGM(newClip, duration, true);
     }
 
-    private IEnumerator SwitchBGMCoroutine(AudioClip newClip, float duration)
+    public void SwitchBGM(AudioClip newClip, float duration, bool fadeOutCurrent)
     {
-        if (bgmSource.isPlaying)
+        if (bgmSource == null || newClip == null)
+            return;
+
+        bgmFadeTween?.Kill();
+
+        if (bgmSource.clip == newClip)
         {
-            yield return FadeOutCoroutine(bgmSource, duration);
-            bgmSource.Stop();
+            if (!bgmSource.isPlaying)
+                PlayBGM(newClip);
+            return;
         }
 
-        bgmSource.clip = newClip;
-        bgmSource.loop = true;
-        bgmSource.volume = 0f;
-        bgmSource.Play();
+        float fadeDuration = Mathf.Max(0f, duration);
+        Sequence sequence = DOTween.Sequence().SetUpdate(true);
 
-        yield return FadeInCoroutine(bgmSource, duration);
+        if (fadeOutCurrent && bgmSource.isPlaying)
+        {
+            sequence.Append(bgmSource.DOFade(0f, fadeDuration));
+        }
+
+        sequence.AppendCallback(() =>
+        {
+            bgmSource.Stop();
+            bgmSource.clip = newClip;
+            bgmSource.loop = true;
+            bgmSource.volume = 0f;
+            bgmSource.Play();
+        });
+        sequence.Append(bgmSource.DOFade(1f, fadeDuration));
+        bgmFadeTween = sequence;
+    }
+
+    public bool ShouldTransitionBGM(string sceneName)
+    {
+        AudioClip sceneBgmClip = GetSceneBGM(sceneName);
+        return bgmSource != null && sceneBgmClip != null && bgmSource.clip != sceneBgmClip;
+    }
+
+    public void BeginSceneTransitionFadeOut(string sceneName)
+    {
+        if (!ShouldTransitionBGM(sceneName))
+            return;
+
+        BgFadeOut(SceneBgmFadeDuration);
+    }
+
+    public void ApplySceneBGM(string sceneName)
+    {
+        AudioClip sceneBgmClip = GetSceneBGM(sceneName);
+        if (sceneBgmClip == null)
+            return;
+
+        SwitchBGM(sceneBgmClip, SceneBgmFadeDuration, false);
+    }
+
+    private AudioClip GetSceneBGM(string sceneName)
+    {
+        switch (sceneName)
+        {
+            case "MainScene":
+            case "MapScene":
+            case "RewardScene":
+            case "ResultScene":
+                return titleBgmClip;
+            case "MainGameScene":
+                return battleBgmClip;
+            default:
+                return null;
+        }
     }
 
     // ── BGM 페이드 (내부 bgmSource 사용) ─────────────────
 
     public void BgFadeIn(float duration = 0.8f)
     {
-        StartCoroutine(FadeInCoroutine(bgmSource, duration));
+        if (bgmSource == null)
+            return;
+
+        bgmFadeTween?.Kill();
+        bgmFadeTween = bgmSource.DOFade(1f, Mathf.Max(0f, duration)).SetUpdate(true);
     }
 
     public void BgFadeOut(float duration = 0.8f)
     {
-        StartCoroutine(FadeOutCoroutine(bgmSource, duration));
+        if (bgmSource == null)
+            return;
+
+        bgmFadeTween?.Kill();
+        bgmFadeTween = bgmSource.DOFade(0f, Mathf.Max(0f, duration)).SetUpdate(true);
     }
 
     // ── BGM 페이드 (외부 AudioSource 사용, 기존 오버로드 유지) ──

--- a/ChaosChess_v2/Assets/Script/SoundManager.cs
+++ b/ChaosChess_v2/Assets/Script/SoundManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using DG.Tweening;
 using UnityEngine;
 using UnityEngine.Audio;
@@ -6,13 +7,19 @@ using UnityEngine.Audio;
 
 public class SoundManager : MonoBehaviour
 {
+    [System.Serializable]
+    private class SceneBgmMapping
+    {
+        public string sceneName;
+        public AudioClip bgmClip;
+    }
+
     private const float DefaultSceneBgmFadeDuration = 0.8f;
     private static SoundManager instance;
 
     public AudioMixer audioMixer;
     [SerializeField] private AudioSource bgmSource;
-    [SerializeField] private AudioClip titleBgmClip;
-    [SerializeField] private AudioClip battleBgmClip;
+    [SerializeField] private List<SceneBgmMapping> sceneBgmMappings = new();
     [SerializeField] private float sceneBgmFadeDuration = 0.8f;
 
     private Tween bgmFadeTween;
@@ -28,14 +35,6 @@ public class SoundManager : MonoBehaviour
         }
         else
         {
-            AudioClip sceneBgmClip = bgmSource != null ? bgmSource.clip : null;
-            bgmSource?.Stop();
-
-            if (sceneBgmClip != null)
-            {
-                instance.SwitchBGM(sceneBgmClip, instance.SceneBgmFadeDuration, false);
-            }
-
             Destroy(gameObject);
         }
     }
@@ -163,18 +162,13 @@ public class SoundManager : MonoBehaviour
 
     private AudioClip GetSceneBGM(string sceneName)
     {
-        switch (sceneName)
+        foreach (SceneBgmMapping mapping in sceneBgmMappings)
         {
-            case "MainScene":
-            case "MapScene":
-            case "RewardScene":
-            case "ResultScene":
-                return titleBgmClip;
-            case "MainGameScene":
-                return battleBgmClip;
-            default:
-                return null;
+            if (mapping.sceneName == sceneName)
+                return mapping.bgmClip;
         }
+
+        return null;
     }
 
     // ── BGM 페이드 (내부 bgmSource 사용) ─────────────────

--- a/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
@@ -51,6 +51,9 @@ public class SceneLoadManager : MonoBehaviour
     private IEnumerator LoadSceneCoroutine(string sceneName)
     {
         isLoading = true;
+
+        SoundManager.Instance?.BeginSceneTransitionFadeOut(sceneName);
+
         SceneLoadingOverlayBase overlayUI = GetOverlayFor(sceneName);
         if (overlayUI != null)
         {
@@ -78,6 +81,8 @@ public class SceneLoadManager : MonoBehaviour
 
         while (!operation.isDone)
             yield return null;
+
+        SoundManager.Instance?.ApplySceneBGM(sceneName);
 
         Tween fadeOut = overlayUI?.FadeTo(0f, fadeDuration);
         if (fadeOut != null)


### PR DESCRIPTION
## 개요

씬 전환 시 BGM 페이드 전환이 동작하지 않던 문제를 수정했습니다.

## 설명

`DontDestroyOnLoad`로 유지되는 기존 `SoundManager` 때문에 새 씬의 BGM 설정이 적용되지 않던 것이 원인이었습니다.
씬 로딩 흐름에서 기존 BGM을 페이드 아웃하고, 씬별 BGM 매핑을 통해 새 BGM을 페이드 인하도록 변경했습니다.

또한 `MapScene`, `RewardScene`, `ResultScene`은 타이틀 BGM을 공유하도록 정리했습니다.