### PR TITLE
[Feature] 타일 이펙트 애니메이션 시스템 추가

### DIFF
--- a/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
+++ b/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
@@ -24,6 +24,9 @@ public class CardDataSOEditor : Editor
     SerializedProperty effectTileBase;
     SerializedProperty useMultipleEffectTileBases;
     SerializedProperty effectTileBases;
+    SerializedProperty effectTileAnimationMode;
+    SerializedProperty effectTileFrameInterval;
+    SerializedProperty effectTileAnimationFrames;
     SerializedProperty restrictTiles;
     SerializedProperty blockedTiles;
 
@@ -51,6 +54,7 @@ public class CardDataSOEditor : Editor
     // 스타일 캐시
     GUIStyle headerStyle;
     GUIStyle sectionBoxStyle;
+    GUIStyle subSectionBoxStyle;
 
     void OnEnable()
     {
@@ -71,6 +75,9 @@ public class CardDataSOEditor : Editor
         effectTileBase = serializedObject.FindProperty("EffectTileBase");
         useMultipleEffectTileBases = serializedObject.FindProperty("UseMultipleEffectTileBases");
         effectTileBases = serializedObject.FindProperty("EffectTileBases");
+        effectTileAnimationMode = serializedObject.FindProperty("EffectTileAnimationMode");
+        effectTileFrameInterval = serializedObject.FindProperty("EffectTileFrameInterval");
+        effectTileAnimationFrames = serializedObject.FindProperty("EffectTileAnimationFrames");
         restrictTiles = serializedObject.FindProperty("RestrictTiles");
         blockedTiles = serializedObject.FindProperty("BlockedTiles");
 
@@ -209,16 +216,7 @@ public class CardDataSOEditor : Editor
             EditorGUILayout.HelpBox("-1 : 제한 없이 계속 유지됩니다.", MessageType.Warning);
         }
 
-        EditorGUILayout.Space(4);
-        EditorGUILayout.PropertyField(needEffectTileBase, new GUIContent("이펙트 타일 필요"));
-        if (needEffectTileBase.boolValue)
-        {
-            EditorGUILayout.PropertyField(useMultipleEffectTileBases, new GUIContent("다중 타일 베이스 사용"));
-            if (useMultipleEffectTileBases.boolValue)
-                EditorGUILayout.PropertyField(effectTileBases, new GUIContent("타일 베이스 목록"), true);
-            else
-                EditorGUILayout.PropertyField(effectTileBase, new GUIContent("타일 베이스"));
-        }
+        DrawTileEffectFields();
 
         EditorGUILayout.Space(4);
         EditorGUILayout.PropertyField(restrictTiles, new GUIContent("타일 제한 사용"));
@@ -232,6 +230,71 @@ public class CardDataSOEditor : Editor
             EditorGUILayout.LabelField("선택 불가 타일 설정 (체크 = 선택 불가)", EditorStyles.boldLabel);
             EditorGUILayout.Space(2);
             DrawTileGrid();
+        }
+    }
+
+    void DrawTileEffectFields()
+    {
+        EditorGUILayout.Space(6);
+        using (new EditorGUILayout.VerticalScope(subSectionBoxStyle))
+        {
+            EditorGUILayout.LabelField("이펙트 타일 설정", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(needEffectTileBase, new GUIContent("이펙트 타일 사용"));
+
+            if (!needEffectTileBase.boolValue)
+                return;
+
+            DrawTileEffectAnimationFields();
+            if ((TileEffectAnimationMode)effectTileAnimationMode.enumValueIndex == TileEffectAnimationMode.None)
+                DrawTileEffectBaseFields();
+        }
+    }
+
+    void DrawTileEffectBaseFields()
+    {
+        EditorGUILayout.Space(4);
+        using (new EditorGUILayout.VerticalScope(subSectionBoxStyle))
+        {
+            EditorGUILayout.LabelField("타일 베이스", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(useMultipleEffectTileBases, new GUIContent("다중 타일 베이스 사용"));
+            if (useMultipleEffectTileBases.boolValue)
+                EditorGUILayout.PropertyField(effectTileBases, new GUIContent("타일 베이스 목록"), true);
+            else
+                EditorGUILayout.PropertyField(effectTileBase, new GUIContent("타일 베이스"));
+        }
+    }
+
+    void DrawTileEffectAnimationFields()
+    {
+        EditorGUILayout.Space(4);
+        using (new EditorGUILayout.VerticalScope(subSectionBoxStyle))
+        {
+            EditorGUILayout.LabelField("애니메이션", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(effectTileAnimationMode, new GUIContent("애니메이션 방식"));
+
+            var mode = (TileEffectAnimationMode)effectTileAnimationMode.enumValueIndex;
+            if (mode == TileEffectAnimationMode.None)
+            {
+                EditorGUILayout.HelpBox("애니메이션을 사용하지 않으면 아래 타일 베이스가 표시됩니다.", MessageType.None);
+                return;
+            }
+
+            EditorGUI.indentLevel++;
+            EditorGUILayout.PropertyField(effectTileAnimationFrames, new GUIContent("프레임"), true);
+
+            if (mode == TileEffectAnimationMode.Time)
+            {
+                EditorGUILayout.PropertyField(effectTileFrameInterval, new GUIContent("프레임 간격(초)"));
+            }
+            else if (mode == TileEffectAnimationMode.Turn)
+            {
+                EditorGUILayout.HelpBox("0번 프레임 = 시작, 1번 프레임 = 1턴 경과", MessageType.None);
+            }
+
+            if (effectTileAnimationFrames.arraySize == 0)
+                EditorGUILayout.HelpBox("프레임이 비어 있으면 기본 타일 베이스가 표시됩니다.", MessageType.Warning);
+
+            EditorGUI.indentLevel--;
         }
     }
 
@@ -353,6 +416,15 @@ public class CardDataSOEditor : Editor
             sectionBoxStyle = new GUIStyle(GUI.skin.box)
             {
                 padding = new RectOffset(10, 10, 8, 8),
+            };
+        }
+
+        if (subSectionBoxStyle == null)
+        {
+            subSectionBoxStyle = new GUIStyle(EditorStyles.helpBox)
+            {
+                padding = new RectOffset(8, 8, 6, 6),
+                margin = new RectOffset(0, 0, 4, 4),
             };
         }
     }

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -1,6 +1,13 @@
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
+public enum TileEffectAnimationMode
+{
+    None,
+    Time,
+    Turn
+}
+
 [CreateAssetMenu(fileName = "Card Data", menuName = "Card/Card Data")]
 public class CardDataSO : ScriptableObject
 {
@@ -50,6 +57,11 @@ public class CardDataSO : ScriptableObject
     /// 선택 순서별로 표시할 타일베이스 목록입니다.
     /// </summary>
     public TileBase[] EffectTileBases;
+    public TileEffectAnimationMode EffectTileAnimationMode = TileEffectAnimationMode.None;
+    [Min(0.01f)]
+    public float EffectTileFrameInterval = 0.2f;
+    [Tooltip("시간 기반 애니메이션 프레임 또는 턴 기반 상태 프레임입니다.")]
+    public TileBase[] EffectTileAnimationFrames;
 
     public TileBase GetEffectTileBase(int index)
     {
@@ -63,6 +75,17 @@ public class CardDataSO : ScriptableObject
             return EffectTileBases[index];
 
         return EffectTileBases[0] != null ? EffectTileBases[0] : EffectTileBase;
+    }
+
+    public TileBase GetEffectTileAnimationFrame(int frameIndex, int effectTileIndex = 0)
+    {
+        if (EffectTileAnimationFrames == null || EffectTileAnimationFrames.Length == 0)
+            return GetEffectTileBase(effectTileIndex);
+
+        int safeIndex = Mathf.Clamp(frameIndex, 0, EffectTileAnimationFrames.Length - 1);
+        return EffectTileAnimationFrames[safeIndex] != null
+            ? EffectTileAnimationFrames[safeIndex]
+            : GetEffectTileBase(effectTileIndex);
     }
     /// <summary>
     /// 활성화 시 BlockedTiles 배열 기준으로 선택 불가 타일을 지정합니다.

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -175,14 +175,18 @@ public abstract class Effector : MonoBehaviour, IEffect
     {
         CardDataSO dataSO = VisualDataSO;
 
+        bool hasAnimationFrames = dataSO != null
+            && dataSO.EffectTileAnimationFrames != null
+            && dataSO.EffectTileAnimationFrames.Length > 0;
+
         TileBase tileBase = GetVisualTileBase();
-        if (dataSO == null || !dataSO.NeedEffectTileBase || tileBase == null)
+        if (dataSO == null || !dataSO.NeedEffectTileBase || (tileBase == null && !hasAnimationFrames))
             return;
 
         foreach (Vector3Int pos in GetVisualPositions())
         {
             if (enabled)
-                BoardManager.Instance?.TileEffectDrawer?.SetTileEffect(pos, tileBase);
+                BoardManager.Instance?.TileEffectDrawer?.SetTileEffect(pos, dataSO, GetVisualEffectTileIndex(), RemainingTurns);
             else
                 BoardManager.Instance?.TileEffectDrawer?.ClearTileEffect(pos);
         }
@@ -196,6 +200,9 @@ public abstract class Effector : MonoBehaviour, IEffect
 
     /// <summary>타일 연출에 사용할 타일베이스입니다. 필요 시 서브 클래스에서 재정의합니다.</summary>
     protected virtual TileBase GetVisualTileBase() => VisualDataSO?.EffectTileBase;
+
+    /// <summary>선택 순서별 타일 연출 인덱스입니다. 필요 시 서브 클래스에서 재정의합니다.</summary>
+    protected virtual int GetVisualEffectTileIndex() => 0;
 }
 
 /// <summary>기물에 부착되는 효과의 기반 추상 클래스</summary>
@@ -260,6 +267,14 @@ public abstract class TileEffector : Effector, ITileEffect
     public virtual void OnPieceExit(Piece piece) { }
     public virtual bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to) { return true; }
 
+    public override void OnTurnChanged()
+    {
+        base.OnTurnChanged();
+
+        if (IsApplied && !IsExpired)
+            RefreshTileEffectTurnAnimation();
+    }
+
     protected override void OnSuspendForArena()
     {
         BoardManager.Instance?.UnregisterTileEffector(tilePos, this);
@@ -280,6 +295,34 @@ public abstract class TileEffector : Effector, ITileEffect
     protected TileBase EffectTileBase => CardSO?.GetEffectTileBase(effectTileIndex);
 
     protected override TileBase GetVisualTileBase() => EffectTileBase;
+    protected override int GetVisualEffectTileIndex() => effectTileIndex;
+
+    protected void ShowTileEffect(CardDataSO dataSO = null)
+    {
+        CardDataSO visualData = dataSO != null ? dataSO : CardSO;
+        if (visualData == null || !visualData.NeedEffectTileBase)
+            return;
+
+        BoardManager.Instance?.TileEffectDrawer?.SetTileEffect(
+            tilePos,
+            visualData,
+            effectTileIndex,
+            RemainingTurns);
+    }
+
+    protected void ClearTileEffect()
+    {
+        BoardManager.Instance?.TileEffectDrawer?.ClearTileEffect(tilePos);
+    }
+
+    protected void RefreshTileEffectTurnAnimation(CardDataSO dataSO = null)
+    {
+        CardDataSO visualData = dataSO != null ? dataSO : CardSO;
+        if (visualData == null || visualData.EffectTileAnimationMode != TileEffectAnimationMode.Turn)
+            return;
+
+        BoardManager.Instance?.TileEffectDrawer?.TickTurnAnimation(tilePos, RemainingTurns);
+    }
 }
 
 /// <summary>특정 타입의 기물이 행동(이동/잡기)했을 때 반응하는 전역 효과의 기반 추상 클래스</summary>

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -315,13 +315,14 @@ public abstract class TileEffector : Effector, ITileEffect
         BoardManager.Instance?.TileEffectDrawer?.ClearTileEffect(tilePos);
     }
 
-    protected void RefreshTileEffectTurnAnimation(CardDataSO dataSO = null)
+    protected void RefreshTileEffectTurnAnimation(CardDataSO dataSO = null, int customRemainingTurns = -1)
     {
         CardDataSO visualData = dataSO != null ? dataSO : CardSO;
         if (visualData == null || visualData.EffectTileAnimationMode != TileEffectAnimationMode.Turn)
             return;
 
-        BoardManager.Instance?.TileEffectDrawer?.TickTurnAnimation(tilePos, RemainingTurns);
+        int turns = customRemainingTurns >= 0 ? customRemainingTurns : RemainingTurns;
+        BoardManager.Instance?.TileEffectDrawer?.TickTurnAnimation(tilePos, turns);
     }
 }
 

--- a/ChaosChess_v2/Assets/Script/Card/SO/TimeBomb.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/TimeBomb.asset
@@ -25,6 +25,14 @@ MonoBehaviour:
   MaintainTurn: 3
   NeedEffectTileBase: 1
   EffectTileBase: {fileID: 11400000, guid: 22fb84878390e6941b631e2b2faa1ef9, type: 2}
+  UseMultipleEffectTileBases: 0
+  EffectTileBases: []
+  EffectTileAnimationMode: 2
+  EffectTileFrameInterval: 0.2
+  EffectTileAnimationFrames:
+  - {fileID: 11400000, guid: 22fb84878390e6941b631e2b2faa1ef9, type: 2}
+  - {fileID: 11400000, guid: e31b6f0c00b9d6249b9d20ee3a9cf7ec, type: 2}
+  - {fileID: 11400000, guid: 475a875d917caec449047f70d8fc11fb, type: 2}
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0

--- a/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
@@ -36,9 +36,7 @@ public class FireEffect : TileEffector
     {
         Piece.OnPieceDestroyed += HandlePieceDestroyed;
 
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         boardManager.RegisterTileEffector(tilePos, this);
     }
@@ -47,9 +45,7 @@ public class FireEffect : TileEffector
     {
         Piece.OnPieceDestroyed -= HandlePieceDestroyed;
 
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         Destroy(gameObject);
     }
@@ -79,6 +75,8 @@ public class FireEffect : TileEffector
                 Revert();
             }
         }
+
+        RefreshTileEffectTurnAnimation(DataSO);
     }
 
     protected override void OnDestroy()

--- a/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/FireCard.cs
@@ -76,7 +76,7 @@ public class FireEffect : TileEffector
             }
         }
 
-        RefreshTileEffectTurnAnimation(DataSO);
+        RefreshTileEffectTurnAnimation(DataSO, 2 - deathTurn);
     }
 
     protected override void OnDestroy()

--- a/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/ObeyOrderCard.cs
@@ -216,7 +216,7 @@ public class ObeyOrderEffect : TileEffector
 
         visualTilePos = pos;
         hasVisualTile = true;
-        BoardManager.Instance.TileEffectDrawer.SetTileEffect(visualTilePos, DataSO.EffectTileBase);
+        BoardManager.Instance.TileEffectDrawer.SetTileEffect(visualTilePos, DataSO, 0, RemainingTurns);
     }
 
     private void ClearVisualTile()

--- a/ChaosChess_v2/Assets/Script/Card/Skills/PortalCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/PortalCard.cs
@@ -56,18 +56,14 @@ public class PortalEffect : TileEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);

--- a/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/SyncCard.cs
@@ -50,12 +50,11 @@ public class SyncEffect : TileEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
         {
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO, 0, RemainingTurns);
             if (child != null)
-                BoardManager.Instance.TileEffectDrawer.SetTileEffect(child.TilePos, DataSO.EffectTileBase);
+                BoardManager.Instance.TileEffectDrawer.SetTileEffect(child.TilePos, DataSO, 0, child.RemainingTurns);
         }
 
         if (LinkLineSettings.Enabled && child != null)
@@ -142,9 +141,7 @@ public class SyncChild : TileEffector
     {
         Piece.OnPieceDestroyed += HandlePieceDestroyed;
 
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
@@ -224,9 +221,8 @@ public class SyncFollower : PieceEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(syncTilePos, DataSO.EffectTileBase);
+            BoardManager.Instance.TileEffectDrawer.SetTileEffect(syncTilePos, DataSO, 0, RemainingTurns);
 
         isReady = false;
     }

--- a/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
+++ b/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
@@ -5,15 +5,98 @@ using System.Collections.Generic;
 public class UITileEffectDrawer : MonoBehaviour
 {
     [SerializeField] private Tilemap effectTilemap;
+    private readonly Dictionary<Vector3Int, TileEffectAnimationState> animationStates = new();
+
+    private class TileEffectAnimationState
+    {
+        public CardDataSO DataSO;
+        public int EffectTileIndex;
+        public int InitialRemainingTurns;
+        public int FrameIndex;
+        public float Elapsed;
+
+        public TileEffectAnimationState(CardDataSO dataSO, int effectTileIndex, int initialRemainingTurns, int initialFrame)
+        {
+            DataSO = dataSO;
+            EffectTileIndex = effectTileIndex;
+            InitialRemainingTurns = initialRemainingTurns;
+            FrameIndex = initialFrame;
+        }
+    }
+
+    private void Update()
+    {
+        if (effectTilemap == null || animationStates.Count == 0)
+            return;
+
+        foreach (var pair in animationStates)
+        {
+            TileEffectAnimationState state = pair.Value;
+            CardDataSO dataSO = state.DataSO;
+            if (dataSO == null || dataSO.EffectTileAnimationMode != TileEffectAnimationMode.Time)
+                continue;
+
+            float frameInterval = Mathf.Max(0.01f, dataSO.EffectTileFrameInterval);
+            state.Elapsed += Time.deltaTime;
+            if (state.Elapsed < frameInterval)
+                continue;
+
+            while (state.Elapsed >= frameInterval)
+            {
+                state.Elapsed -= frameInterval;
+                AdvanceFrame(pair.Key, state);
+            }
+        }
+    }
 
     public void SetTileEffect(Vector3Int pos, TileBase tile)
     {
+        animationStates.Remove(pos);
+
         if (effectTilemap != null)
             effectTilemap.SetTile(pos, tile);
     }
 
+    public void SetTileEffect(Vector3Int pos, CardDataSO dataSO, int effectTileIndex = 0, int remainingTurns = -1)
+    {
+        if (effectTilemap == null || dataSO == null)
+            return;
+
+        TileBase initialTile = dataSO.GetEffectTileBase(effectTileIndex);
+
+        if (dataSO.EffectTileAnimationMode == TileEffectAnimationMode.None)
+        {
+            SetTileEffect(pos, initialTile);
+            return;
+        }
+
+        int initialFrame = 0;
+        var state = new TileEffectAnimationState(dataSO, effectTileIndex, remainingTurns, initialFrame);
+        animationStates[pos] = state;
+        effectTilemap.SetTile(pos, dataSO.GetEffectTileAnimationFrame(initialFrame, effectTileIndex));
+    }
+
+    public void TickTurnAnimation(Vector3Int pos, int remainingTurns = -1)
+    {
+        if (effectTilemap == null)
+            return;
+
+        if (!animationStates.TryGetValue(pos, out TileEffectAnimationState state))
+            return;
+
+        CardDataSO dataSO = state.DataSO;
+        if (dataSO == null || dataSO.EffectTileAnimationMode != TileEffectAnimationMode.Turn)
+            return;
+
+        state.FrameIndex = GetTurnFrame(state, remainingTurns);
+
+        effectTilemap.SetTile(pos, dataSO.GetEffectTileAnimationFrame(state.FrameIndex, state.EffectTileIndex));
+    }
+
     public void ClearTileEffect(Vector3Int pos)
     {
+        animationStates.Remove(pos);
+
         if (effectTilemap != null)
             effectTilemap.SetTile(pos, null);
     }
@@ -38,6 +121,7 @@ public class UITileEffectDrawer : MonoBehaviour
     public void RestoreTileEffects(Dictionary<Vector3Int, TileBase> snapshot)
     {
         if (effectTilemap == null) return;
+        animationStates.Clear();
         effectTilemap.ClearAllTiles();
 
         if (snapshot == null)
@@ -52,7 +136,41 @@ public class UITileEffectDrawer : MonoBehaviour
     /// <summary>타일 이펙트 맵을 전체 초기화합니다.</summary>
     public void ClearAllTileEffects()
     {
+        animationStates.Clear();
+
         if (effectTilemap != null)
             effectTilemap.ClearAllTiles();
+    }
+
+    private int GetTurnFrame(TileEffectAnimationState state, int remainingTurns)
+    {
+        CardDataSO dataSO = state.DataSO;
+        int frameCount = dataSO.EffectTileAnimationFrames != null
+            ? dataSO.EffectTileAnimationFrames.Length
+            : 0;
+
+        if (frameCount <= 0 || state.InitialRemainingTurns < 0 || remainingTurns < 0)
+            return 0;
+
+        int elapsedTurns = state.InitialRemainingTurns - remainingTurns;
+        return Mathf.Clamp(elapsedTurns, 0, frameCount - 1);
+    }
+
+    private void AdvanceFrame(Vector3Int pos, TileEffectAnimationState state)
+    {
+        CardDataSO dataSO = state.DataSO;
+        int frameCount = dataSO.EffectTileAnimationFrames != null
+            ? dataSO.EffectTileAnimationFrames.Length
+            : 0;
+
+        if (frameCount <= 0)
+            return;
+
+        int nextFrame = state.FrameIndex + 1;
+        if (nextFrame >= frameCount)
+            nextFrame = 0;
+
+        state.FrameIndex = nextFrame;
+        effectTilemap.SetTile(pos, dataSO.GetEffectTileAnimationFrame(state.FrameIndex, state.EffectTileIndex));
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
+++ b/ChaosChess_v2/Assets/Script/Card/UI/UITileEffectDrawer.cs
@@ -41,11 +41,9 @@ public class UITileEffectDrawer : MonoBehaviour
             if (state.Elapsed < frameInterval)
                 continue;
 
-            while (state.Elapsed >= frameInterval)
-            {
-                state.Elapsed -= frameInterval;
-                AdvanceFrame(pair.Key, state);
-            }
+            int framesToAdvance = Mathf.FloorToInt(state.Elapsed / frameInterval);
+            state.Elapsed %= frameInterval;
+            AdvanceFrame(pair.Key, state, framesToAdvance);
         }
     }
 
@@ -156,7 +154,7 @@ public class UITileEffectDrawer : MonoBehaviour
         return Mathf.Clamp(elapsedTurns, 0, frameCount - 1);
     }
 
-    private void AdvanceFrame(Vector3Int pos, TileEffectAnimationState state)
+    private void AdvanceFrame(Vector3Int pos, TileEffectAnimationState state, int framesToAdvance = 1)
     {
         CardDataSO dataSO = state.DataSO;
         int frameCount = dataSO.EffectTileAnimationFrames != null
@@ -166,11 +164,7 @@ public class UITileEffectDrawer : MonoBehaviour
         if (frameCount <= 0)
             return;
 
-        int nextFrame = state.FrameIndex + 1;
-        if (nextFrame >= frameCount)
-            nextFrame = 0;
-
-        state.FrameIndex = nextFrame;
+        state.FrameIndex = (state.FrameIndex + framesToAdvance) % frameCount;
         effectTilemap.SetTile(pos, dataSO.GetEffectTileAnimationFrame(state.FrameIndex, state.EffectTileIndex));
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
@@ -47,16 +47,14 @@ public class ATMineEffector : GlobalEffector
     public Vector3Int MinePos;
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(MinePos, DataSO.EffectTileBase);
+            BoardManager.Instance.TileEffectDrawer.SetTileEffect(MinePos, DataSO, 0, RemainingTurns);
 
         BoardManager.Instance.RegisterGlobalEffector(this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(MinePos);
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/BlessingCard.cs
@@ -50,9 +50,7 @@ public class BlessingEffect : TileEffector
     {
         Piece.OnPieceDestroyed += HandlePieceDestroyed;
 
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
@@ -61,9 +59,7 @@ public class BlessingEffect : TileEffector
     {
         Piece.OnPieceDestroyed -= HandlePieceDestroyed;
 
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -43,16 +43,14 @@ public class CobwebEffector : GlobalEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
         if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(TilePos, DataSO.EffectTileBase);
+            BoardManager.Instance.TileEffectDrawer.SetTileEffect(TilePos, DataSO, 0, RemainingTurns);
 
         BoardManager.Instance.RegisterGlobalEffector(this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
         if (DataSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(TilePos);
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/JumpingPlatformCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/JumpingPlatformCard.cs
@@ -38,18 +38,14 @@ public class JumpingPlatformEffect : TileEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);

--- a/ChaosChess_v2/Assets/Script/Card/skills/PeaceZoneCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PeaceZoneCard.cs
@@ -37,18 +37,14 @@ public class PeaceZoneCardEffect : TileEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);

--- a/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PsilocybinMushroomCard.cs
@@ -37,18 +37,14 @@ public class PsilocybinMushroomTileEffect : TileEffector
 
     protected override void OnApply()
     {
-        // 타일 이펙트 추가
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, DataSO.EffectTileBase);
+        ShowTileEffect(DataSO);
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        // 타일 이펙트 제거
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         Destroy(gameObject);
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/TimeBombCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/TimeBombCard.cs
@@ -34,16 +34,14 @@ public class TimeBombEffector : TileEffector
 {
     protected override void OnApply()
     {
-        if (CardSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(tilePos, CardSO.EffectTileBase);
+        ShowTileEffect();
 
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        if (CardSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(tilePos);
+        ClearTileEffect();
 
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);


### PR DESCRIPTION
## 해결한 이슈
- #196

## 개요
타일 위에 표시되는 이펙트가 정적 타일뿐 아니라 애니메이션 프레임을 사용할 수 있도록 확장했습니다.

## 변경 사항
- 타일 이펙트 애니메이션 모드 추가
  - `Time`: 시간 간격에 따라 프레임 반복 재생
  - `Turn`: 턴 경과에 따라 프레임 변경
- `CardDataSO`에 타일 이펙트 애니메이션 프레임 설정 추가
- `UITileEffectDrawer`에서 시간 기반/턴 기반 타일 애니메이션 처리
- `TileEffector` 공통 헬퍼를 통해 기존 타일 이펙트 카드들이 애니메이션 설정을 사용할 수 있도록 연결
- `CardDataSOEditor`에서 이펙트 타일 설정과 애니메이션 설정을 분리해 표시
- 시한폭탄 카드에 턴 기반 애니메이션 프레임 적용

## 참고
불바다, 평화협정공간에도 애니메이션 시스템을 적용할 수 있도록 런타임 연결은 해두었지만, 현재 해당 카드에 사용할 애니메이션 프레임 에셋이 아직 제작되지 않아 실제 프레임 설정은 적용하지 않았습니다. 프레임 에셋이 준비되면 카드 SO에서 애니메이션 방식과 프레임만 지정하면 됩니다.