### PR TITLE
[Fix] 카드 사용 조건 및 선택 상태 처리 버그 수정

### DIFF
--- a/ChaosChess_v2/Assets/Script/Card/SO/DesperadoCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/DesperadoCard.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   CardTier: 4
   PieceType: 63
   PieceTargetColor: 0
-  PieceLimitTurn: 0
+  PieceLimitTurn: 1
   RequiredPieceCount: 1
   TileCount: 0
   MaintainTurn: 0

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -10,6 +10,7 @@ public class PieceSelector : Selector<Piece>
     // GetComponents(List<T>) 재사용 버퍼로 선택 시점 GC 할당을 줄입니다.
     private readonly List<PieceEffector> pieceEffectorBuffer = new();
     private IPieceCard skillCard;
+    private IPieceTargetFilter targetFilter;
     private bool executable => isExecute();
 
     public override void DeselectFirstTarget()
@@ -50,8 +51,7 @@ public class PieceSelector : Selector<Piece>
             if (p != null)
             {
                 // 기물 타입과 색상 체크
-                if((p.Type & cardData.DataSO.PieceType) != 0 &&
-                    p.Color == cardData.DataSO.PieceTargetColor)
+                if (CanSelectPiece(p))
                 {
                     SelectTarget(p);
                 }
@@ -62,6 +62,12 @@ public class PieceSelector : Selector<Piece>
     public override void SelectTarget(Piece Target)
     {
         if (!selectState) return;
+
+        if (!CanSelectPiece(Target))
+        {
+            Target.NotSelect();
+            return;
+        }
 
         if (HasActivePieceEffector(Target))
         {
@@ -122,8 +128,7 @@ public class PieceSelector : Selector<Piece>
 
         // 1. 현재 기물 검사
         List<Piece> pieces = bm.GetAllPieces()
-            .Where(p => (p.Type & cardData.DataSO.PieceType) != 0 &&
-                    p.Color == cardData.DataSO.PieceTargetColor)
+            .Where(CanSelectPiece)
             .ToList();
 
         if (pieces.Count == 0)
@@ -150,6 +155,7 @@ public class PieceSelector : Selector<Piece>
     {
         cardData = data;
         skillCard = cardData.GetComponent<IPieceCard>();
+        targetFilter = cardData.GetComponent<IPieceTargetFilter>();
         selectorUI.DisableButtonState();
         selectedTargets.Clear();
 
@@ -185,10 +191,25 @@ public class PieceSelector : Selector<Piece>
 
         cardData = null;
         skillCard = null;
+        targetFilter = null;
         foreach(Piece p in selectedTargets) p.OnDeselect();
         selectedTargets.Clear();
         selectorUI.DisableButtonState();
 
+    }
+
+    private bool CanSelectPiece(Piece piece)
+    {
+        if (piece == null || cardData == null || cardData.DataSO == null)
+            return false;
+
+        if ((piece.Type & cardData.DataSO.PieceType) == 0)
+            return false;
+
+        if (piece.Color != cardData.DataSO.PieceTargetColor)
+            return false;
+
+        return targetFilter == null || targetFilter.CanSelectPiece(piece);
     }
 
     /// <summary>해당 기물에 일시정지되지 않은 PieceEffector가 하나라도 있는지 확인합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -50,11 +50,7 @@ public class PieceSelector : Selector<Piece>
             // 널 체크
             if (p != null)
             {
-                // 기물 타입과 색상 체크
-                if (CanSelectPiece(p))
-                {
-                    SelectTarget(p);
-                }
+                SelectTarget(p);
             }
         }
     }

--- a/ChaosChess_v2/Assets/Script/Card/Skills/TransmigrationCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/TransmigrationCard.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 /// 윤회 - 기물 전용 (고급)
 /// 프로모션한 상대 폰의 모습과 위치를 되돌립니다.
 /// </summary>
-public class TransmigrationCard : CardData, IPieceCard
+public class TransmigrationCard : CardData, IPieceCard, IPieceTargetFilter
 {
     private PieceSelector selector;
 
@@ -18,6 +18,11 @@ public class TransmigrationCard : CardData, IPieceCard
     {
         if (selector == null) selector = FindFirstObjectByType<PieceSelector>();
         selector.EnableSelector(this);
+    }
+
+    public bool CanSelectPiece(Piece piece)
+    {
+        return piece != null && piece.IsPromotioned;
     }
 
     public void Execute(CardEffectArgs args = null)

--- a/ChaosChess_v2/Assets/Script/Card/skills/Core/ISkillCards.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/Core/ISkillCards.cs
@@ -3,6 +3,11 @@ public interface IPieceCard : ICard
     void LoadPieceSelector();
 }
 
+public interface IPieceTargetFilter
+{
+    bool CanSelectPiece(Piece piece);
+}
+
 public interface ITileCard: ICard
 {
     void LoadTileSelector();

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
@@ -91,6 +91,8 @@ public class CardDescPanel : ButtonPanel
 
         executeButton.onClick.AddListener(() =>
             {
+                if (gameManager == null) gameManager = GameManager.Instance;
+                gameManager?.CancelCurrentSelectionForBoardTransition();
                 DisablePanel();
                 cardExecute?.Invoke();
             }


### PR DESCRIPTION
## 요약
- 윤회 카드 사용 조건을 수정했습니다.
  - 프로모션된 상대 기물이 없으면 카드 선택/사용 단계로 진입하지 않도록 처리했습니다.
  - 윤회 효과가 실제로 적용 가능한 기물만 선택할 수 있도록 대상 필터를 추가했습니다.

- 데스페라도 카드 효과가 정상적으로 유지되도록 수정했습니다.
  - 효과가 적용 직후 만료되어 추가 행동권이 부여되지 않던 문제를 해결했습니다.
  - `PieceLimitTurn` 값을 조정해 첫 이동 후 두 번째 행동까지 효과가 유지되도록 했습니다.

- 카드 사용 시 기존 보드 선택 상태를 초기화하도록 수정했습니다.
  - 기물을 선택한 상태에서 돌격 같은 카드를 사용할 때 선택 타일/이동 가능 타일이 남는 문제를 해결했습니다.
  - 카드 실행 전에 기존 선택 상태를 정리하도록 공통 처리에 반영했습니다.

## 해결한 이슈
- #197
- #207
- #202

## 참고
- #203 민주주의 이슈는 이번 PR에서 수정하지 않았습니다.