### PR TITLE
[Feature] 시작 카드 리롤 기능 추가 및 구성 확장

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -40694,6 +40694,7 @@ GameObject:
   - component: {fileID: 2147483604}
   - component: {fileID: 2147483605}
   - component: {fileID: 2147483610}
+  - component: {fileID: 2147483611}
   m_Layer: 5
   m_Name: RerollButton
   m_TagString: Untagged
@@ -40989,6 +40990,18 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &2147483611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77cc6a751d4a4af4abcf2b7df9117de7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -1925,6 +1925,7 @@ RectTransform:
   - {fileID: 702743065}
   - {fileID: 2126212522}
   - {fileID: 1708510079}
+  - {fileID: 2147483602}
   m_Father: {fileID: 579454194}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3942,7 +3943,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 237120361}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
@@ -4645,6 +4646,82 @@ MonoBehaviour:
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
   mainSceneName: MainScene
+--- !u!1 &272587994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 272587995}
+  - component: {fileID: 272587997}
+  - component: {fileID: 272587996}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &272587995
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 272587994}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1331256272}
+  m_Father: {fileID: 1538030013}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &272587996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 272587994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1320590349, guid: dfc4cdb601625ca46a579e098026e475, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &272587997
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 272587994}
+  m_CullTransparentMesh: 1
 --- !u!1 &274556685
 GameObject:
   m_ObjectHideFlags: 0
@@ -10361,7 +10438,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 579454188}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 1
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
@@ -10519,9 +10596,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uiCardPanel: {fileID: 2126212525}
+  rerollButton: {fileID: 2147483605}
   commonCardCount: 2
-  uncommonCardCount: 1
+  uncommonCardCount: 2
   uniqueCardCount: 1
+  rerollCardInterval: 0.15
+  rerollAnimationDurationMultiplier: 1
 --- !u!1 &582889332
 GameObject:
   m_ObjectHideFlags: 0
@@ -20171,7 +20251,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 627.84, y: 838.08}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1151004695
 CanvasRenderer:
@@ -22913,7 +22993,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 627.84, y: 838.08}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1328922998
 MonoBehaviour:
@@ -23080,6 +23160,143 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1331069058}
+  m_CullTransparentMesh: 1
+--- !u!1 &1331256271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1331256272}
+  - component: {fileID: 1331256274}
+  - component: {fileID: 1331256273}
+  m_Layer: 5
+  m_Name: Text (TMP) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1331256272
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1331256271}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 272587995}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: -90}
+  m_SizeDelta: {x: 350, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1331256273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1331256271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uCE74\uB4DC \uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 20, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1331256274
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1331256271}
   m_CullTransparentMesh: 1
 --- !u!1 &1331357659
 GameObject:
@@ -23410,7 +23627,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 627.84, y: 838.08}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1336530147
 CanvasRenderer:
@@ -27217,6 +27434,72 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1536643388}
   m_CullTransparentMesh: 1
+--- !u!1 &1538030012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1538030013}
+  - component: {fileID: 1538030015}
+  - component: {fileID: 1538030014}
+  m_Layer: 5
+  m_Name: Card (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1538030013
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538030012}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 272587995}
+  m_Father: {fileID: 2126212522}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1538030014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538030012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c462aa921f5d584b8521ab3e9b41937, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startYPos: -300
+  duration: 0.4
+  enableEase: 12
+  disableEase: 14
+  fadeDuration: 0.3
+  cardPrefab: {fileID: 0}
+  cardNameText: {fileID: 1331256273}
+  cardImage: {fileID: 272587996}
+--- !u!222 &1538030015
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538030012}
+  m_CullTransparentMesh: 1
 --- !u!1 &1541234239
 GameObject:
   m_ObjectHideFlags: 0
@@ -27659,7 +27942,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
   m_AnchoredPosition: {x: 0, y: -90}
-  m_SizeDelta: {x: 436, y: 120}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1559772508
 MonoBehaviour:
@@ -27708,8 +27991,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
-  m_fontSizeBase: 72
+  m_fontSize: 60
+  m_fontSizeBase: 60
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -27994,7 +28277,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
   m_AnchoredPosition: {x: 0, y: -90}
-  m_SizeDelta: {x: 436, y: 120}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1595152580
 CanvasRenderer:
@@ -28051,8 +28334,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
-  m_fontSizeBase: 72
+  m_fontSize: 60
+  m_fontSizeBase: 60
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -28919,7 +29202,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
   m_AnchoredPosition: {x: 0, y: -90}
-  m_SizeDelta: {x: 436, y: 120}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1621636298
 MonoBehaviour:
@@ -28968,8 +29251,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
-  m_fontSizeBase: 72
+  m_fontSize: 60
+  m_fontSizeBase: 60
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -29171,6 +29454,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627269860}
+  m_CullTransparentMesh: 1
+--- !u!1 &1630974406
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1630974407}
+  - component: {fileID: 1630974409}
+  - component: {fileID: 1630974408}
+  m_Layer: 5
+  m_Name: Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1630974407
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630974406}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0011734, y: 1.0011734, z: 1.0011734}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 2147483602}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1630974408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630974406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da278b4ad962ea49b52e728dab946b4, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!222 &1630974409
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630974406}
   m_CullTransparentMesh: 1
 --- !u!1 &1635553850
 GameObject:
@@ -34038,7 +34396,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 627.84, y: 838.08}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1832006212
 CanvasRenderer:
@@ -38762,7 +39120,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
   m_AnchoredPosition: {x: 0, y: -90}
-  m_SizeDelta: {x: 436, y: 120}
+  m_SizeDelta: {x: 350, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2052712322
 MonoBehaviour:
@@ -38811,8 +39169,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 72
-  m_fontSizeBase: 72
+  m_fontSize: 60
+  m_fontSizeBase: 60
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -39675,6 +40033,7 @@ RectTransform:
   - {fileID: 1151004694}
   - {fileID: 1336530146}
   - {fileID: 1328922997}
+  - {fileID: 1538030013}
   m_Father: {fileID: 154833870}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -39700,7 +40059,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: -250
+  m_Spacing: -150
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -39741,7 +40100,8 @@ MonoBehaviour:
   - {fileID: 1151004696}
   - {fileID: 1336530145}
   - {fileID: 1328922998}
-  cardCount: 4
+  - {fileID: 1538030014}
+  cardCount: 5
   cardInterval: 0.5
   panelCloseDelay: -1
 --- !u!225 &2126212526
@@ -40321,6 +40681,314 @@ MonoBehaviour:
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
   mainSceneName: MainScene
+--- !u!1 &2147483601
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2147483602}
+  - component: {fileID: 2147483603}
+  - component: {fileID: 2147483604}
+  - component: {fileID: 2147483605}
+  - component: {fileID: 2147483610}
+  m_Layer: 5
+  m_Name: RerollButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2147483602
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2147483607}
+  - {fileID: 1630974407}
+  m_Father: {fileID: 154833870}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 686.2}
+  m_SizeDelta: {x: 576, y: 210}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2147483603
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_CullTransparentMesh: 1
+--- !u!114 &2147483604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.05490196, g: 0.05490196, b: 0.05490196, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2147483605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2147483604}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 579454196}
+        m_TargetAssemblyTypeName: StartDeckManager, Assembly-CSharp
+        m_MethodName: Reroll
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  clickSound: {fileID: 8300000, guid: 472aa3d34b095fa468cc44b3fa88ae6e, type: 3}
+  hoverSound: {fileID: 0}
+  disableCanvas: {fileID: 579454195}
+  enableCanvas: {fileID: 0}
+  disablePanel: {fileID: 0}
+  enablePanel: {fileID: 0}
+  buttonType: 0
+  practiceDifficulty: 1
+  uIAnimationObject: {fileID: 0}
+  isStartAnimation: 0
+  isEndAnimation: 0
+  nextSceneName: 
+  practiceSceneName: MainGameScene
+  rewardSceneName: RewardScene
+  resultSceneName: ResultScene
+  mainSceneName: MainScene
+--- !u!1 &2147483606
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2147483607}
+  - component: {fileID: 2147483608}
+  - component: {fileID: 2147483609}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2147483607
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483606}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2147483602}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2147483608
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483606}
+  m_CullTransparentMesh: 1
+--- !u!114 &2147483609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483606}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB2E4\uC2DC"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 84
+  m_fontSizeBase: 84
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &2147483610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2147483601}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -10597,7 +10597,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   uiCardPanel: {fileID: 2126212525}
   rerollButton: {fileID: 2147483605}
-  commonCardCount: 2
+  commonCardCount: 4
   uncommonCardCount: 2
   uniqueCardCount: 1
   rerollCardInterval: 0.15
@@ -16969,6 +16969,713 @@ MonoBehaviour:
   loadingDisplayDelay: 0.2
   basicOverlay: {fileID: 1000000000000000006, guid: c95bb3f83fc44740b72105a3aa01f584, type: 3}
   rainOverlay: {fileID: 4308635123189978070, guid: f70bac25932e1db44b46c7085c4b697b, type: 3}
+--- !u!1 &910001001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910001002}
+  - component: {fileID: 910001003}
+  - component: {fileID: 910001004}
+  m_Layer: 5
+  m_Name: Card (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910001002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 910001011}
+  m_Father: {fileID: 910004002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910001003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001001}
+  m_CullTransparentMesh: 1
+--- !u!114 &910001004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c462aa921f5d584b8521ab3e9b41937, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startYPos: -300
+  duration: 0.2
+  enableEase: 12
+  disableEase: 14
+  fadeDuration: 0.2
+  cardPrefab: {fileID: 0}
+  cardNameText: {fileID: 910001023}
+  cardImage: {fileID: 910001013}
+--- !u!1 &910001010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910001011}
+  - component: {fileID: 910001012}
+  - component: {fileID: 910001013}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910001011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001010}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 910001021}
+  m_Father: {fileID: 910001002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910001012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001010}
+  m_CullTransparentMesh: 1
+--- !u!114 &910001013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1320590349, guid: dfc4cdb601625ca46a579e098026e475, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &910001020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910001021}
+  - component: {fileID: 910001022}
+  - component: {fileID: 910001023}
+  m_Layer: 5
+  m_Name: Text (TMP) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910001021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001020}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 910001011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: -90}
+  m_SizeDelta: {x: 350, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910001022
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001020}
+  m_CullTransparentMesh: 1
+--- !u!114 &910001023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910001020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uCE74\uB4DC \uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 20, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &910002001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910002002}
+  - component: {fileID: 910002003}
+  - component: {fileID: 910002004}
+  m_Layer: 5
+  m_Name: Card (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910002002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 910002011}
+  m_Father: {fileID: 910004002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 482.95386, y: 644.67694}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910002003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002001}
+  m_CullTransparentMesh: 1
+--- !u!114 &910002004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c462aa921f5d584b8521ab3e9b41937, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startYPos: -300
+  duration: 0.2
+  enableEase: 12
+  disableEase: 14
+  fadeDuration: 0.2
+  cardPrefab: {fileID: 0}
+  cardNameText: {fileID: 910002023}
+  cardImage: {fileID: 910002013}
+--- !u!1 &910002010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910002011}
+  - component: {fileID: 910002012}
+  - component: {fileID: 910002013}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910002011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002010}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 910002021}
+  m_Father: {fileID: 910002002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910002012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002010}
+  m_CullTransparentMesh: 1
+--- !u!114 &910002013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1320590349, guid: dfc4cdb601625ca46a579e098026e475, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &910002020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910002021}
+  - component: {fileID: 910002022}
+  - component: {fileID: 910002023}
+  m_Layer: 5
+  m_Name: Text (TMP) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910002021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002020}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 910002011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: -90}
+  m_SizeDelta: {x: 350, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910002022
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002020}
+  m_CullTransparentMesh: 1
+--- !u!114 &910002023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910002020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uCE74\uB4DC \uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 20, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &910003001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910003002}
+  - component: {fileID: 910003003}
+  - component: {fileID: 910003004}
+  m_Layer: 5
+  m_Name: TopRow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910003002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910003001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1832006211}
+  - {fileID: 1151004694}
+  - {fileID: 1336530146}
+  - {fileID: 1328922997}
+  m_Father: {fileID: 2126212522}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 645}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910003003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910003001}
+  m_CullTransparentMesh: 1
+--- !u!114 &910003004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910003001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: -40
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &910004001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910004002}
+  - component: {fileID: 910004003}
+  - component: {fileID: 910004004}
+  m_Layer: 5
+  m_Name: BottomRow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910004002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910004001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1538030013}
+  - {fileID: 910001002}
+  - {fileID: 910002002}
+  m_Father: {fileID: 2126212522}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 645}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910004003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910004001}
+  m_CullTransparentMesh: 1
+--- !u!114 &910004004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910004001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: -40
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &914143565
 GameObject:
   m_ObjectHideFlags: 0
@@ -20246,7 +20953,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 649316408}
-  m_Father: {fileID: 2126212522}
+  m_Father: {fileID: 910003002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -22988,7 +23695,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 1625685973}
-  m_Father: {fileID: 2126212522}
+  m_Father: {fileID: 910003002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -23622,7 +24329,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 2033418006}
-  m_Father: {fileID: 2126212522}
+  m_Father: {fileID: 910003002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -27465,7 +28172,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 272587995}
-  m_Father: {fileID: 2126212522}
+  m_Father: {fileID: 910004002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -34391,7 +35098,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1442359995}
-  m_Father: {fileID: 2126212522}
+  m_Father: {fileID: 910003002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -40029,11 +40736,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1832006211}
-  - {fileID: 1151004694}
-  - {fileID: 1336530146}
-  - {fileID: 1328922997}
-  - {fileID: 1538030013}
+  - {fileID: 910003002}
+  - {fileID: 910004002}
   m_Father: {fileID: 154833870}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -40050,18 +40754,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 2126212521}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: -150
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+    m_Top: 400
+    m_Bottom: 80
+  m_ChildAlignment: 1
+  m_Spacing: 300
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
@@ -40101,8 +40805,10 @@ MonoBehaviour:
   - {fileID: 1336530145}
   - {fileID: 1328922998}
   - {fileID: 1538030014}
-  cardCount: 5
-  cardInterval: 0.5
+  - {fileID: 910001004}
+  - {fileID: 910002004}
+  cardCount: 7
+  cardInterval: 0.35
   panelCloseDelay: -1
 --- !u!225 &2126212526
 CanvasGroup:
@@ -40720,7 +41426,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 686.2}
+  m_AnchoredPosition: {x: 0, y: -1113.8}
   m_SizeDelta: {x: 576, y: 210}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2147483603

--- a/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
@@ -113,15 +113,6 @@ public class CardRandomizerManager : MonoBehaviour
 
     public List<GameObject> GetRandomCardsByTier(Tier tier, int count)
     {
-        return GetRandomCardsByTier(tier, count, null);
-    }
-
-    public List<GameObject> GetRandomCardsByTier(Tier tier, int count, IEnumerable<GameObject> excludedCards)
-    {
-        HashSet<GameObject> excludedSet = excludedCards != null
-            ? new HashSet<GameObject>(excludedCards)
-            : new HashSet<GameObject>();
-
         List<GameObject> availableCards = allCards
             .Where(card =>
             {
@@ -130,7 +121,6 @@ public class CardRandomizerManager : MonoBehaviour
                 return data != null &&
                        data.DataSO != null &&
                        data.DataSO.CardTier == tier &&
-                       !excludedSet.Contains(card) &&
                        !IsCardActive(data.DataSO);
             })
             .ToList();

--- a/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
@@ -113,6 +113,15 @@ public class CardRandomizerManager : MonoBehaviour
 
     public List<GameObject> GetRandomCardsByTier(Tier tier, int count)
     {
+        return GetRandomCardsByTier(tier, count, null);
+    }
+
+    public List<GameObject> GetRandomCardsByTier(Tier tier, int count, IEnumerable<GameObject> excludedCards)
+    {
+        HashSet<GameObject> excludedSet = excludedCards != null
+            ? new HashSet<GameObject>(excludedCards)
+            : new HashSet<GameObject>();
+
         List<GameObject> availableCards = allCards
             .Where(card =>
             {
@@ -121,6 +130,7 @@ public class CardRandomizerManager : MonoBehaviour
                 return data != null &&
                        data.DataSO != null &&
                        data.DataSO.CardTier == tier &&
+                       !excludedSet.Contains(card) &&
                        !IsCardActive(data.DataSO);
             })
             .ToList();

--- a/ChaosChess_v2/Assets/Script/GameCycle/PlayerState.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/PlayerState.cs
@@ -48,6 +48,13 @@ public class PlayerState : MonoBehaviour
         if (cardData?.DataSO != null && CollectionManager.Instance != null)
             CollectionManager.Instance.Discover(cardData.DataSO.CardName);
     }
+
+    public bool RemoveCard(GameObject card)
+    {
+        if (card == null) return false;
+        return _cardPool.Remove(card);
+    }
+
     public void AddBuff(BuffSO definition, BuffSide side) => _buffs.Add(new BuffPick(definition, side));
     public void AddBuff(BuffSO definition, BuffSide side, int magnitude) => _buffs.Add(new BuffPick(definition, side, magnitude));
 

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers.meta
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ac77081f7c04484b9c26db27d3de83a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers/StartDeckRerollButton.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers/StartDeckRerollButton.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+[RequireComponent(typeof(Button))]
+public class StartDeckRerollButton : MonoBehaviour
+{
+    private Button cachedButton;
+
+    public Button Button
+    {
+        get
+        {
+            if (cachedButton == null)
+                cachedButton = GetComponent<Button>();
+
+            return cachedButton;
+        }
+    }
+}

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers/StartDeckRerollButton.cs.meta
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/Markers/StartDeckRerollButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77cc6a751d4a4af4abcf2b7df9117de7

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -31,24 +31,23 @@ public class StartDeckManager : MonoBehaviour
         CacheRerollButton();
         SetRerollButtonInteractable(false);
         RemoveCurrentStarterCards();
-        DealStarterCards(null);
+        DealStarterCards();
     }
 
     public void Reroll()
     {
         SetRerollButtonInteractable(false);
-        List<GameObject> previousCards = new List<GameObject>(currentStarterCards);
         RemoveCurrentStarterCards();
-        DealStarterCards(previousCards);
+        DealStarterCards();
         uiCardPanel?.RefreshCards(rerollCardInterval, rerollAnimationDurationMultiplier);
     }
 
-    private void DealStarterCards(List<GameObject> excludedCards)
+    private void DealStarterCards()
     {
         CardRandomizerManager randomizer = CardRandomizerManager.Instance;
         if (randomizer == null) return;
 
-        List<GameObject> starterCards = GenerateStarterCards(randomizer, excludedCards);
+        List<GameObject> starterCards = GenerateStarterCards(randomizer);
 
         foreach (var card in starterCards)
         {
@@ -60,12 +59,12 @@ public class StartDeckManager : MonoBehaviour
         uiCardPanel.SetCards(starterCards);
     }
 
-    private List<GameObject> GenerateStarterCards(CardRandomizerManager randomizer, List<GameObject> excludedCards)
+    private List<GameObject> GenerateStarterCards(CardRandomizerManager randomizer)
     {
         List<GameObject> starterCards = new List<GameObject>();
-        AddCardsByTier(starterCards, randomizer, Tier.Common, commonCardCount, excludedCards);
-        AddCardsByTier(starterCards, randomizer, Tier.Uncommon, uncommonCardCount, excludedCards);
-        AddCardsByTier(starterCards, randomizer, Tier.Unique, uniqueCardCount, excludedCards);
+        AddCardsByTier(starterCards, randomizer, Tier.Common, commonCardCount);
+        AddCardsByTier(starterCards, randomizer, Tier.Uncommon, uncommonCardCount);
+        AddCardsByTier(starterCards, randomizer, Tier.Unique, uniqueCardCount);
         return starterCards;
     }
 
@@ -73,18 +72,11 @@ public class StartDeckManager : MonoBehaviour
         List<GameObject> destination,
         CardRandomizerManager randomizer,
         Tier tier,
-        int count,
-        List<GameObject> excludedCards)
+        int count)
     {
         if (count <= 0) return;
 
-        List<GameObject> pickedCards = randomizer.GetRandomCardsByTier(tier, count, excludedCards);
-        if (pickedCards.Count < count && excludedCards != null && excludedCards.Count > 0)
-        {
-            pickedCards.AddRange(randomizer.GetRandomCardsByTier(tier, count - pickedCards.Count, pickedCards));
-        }
-
-        destination.AddRange(pickedCards);
+        destination.AddRange(randomizer.GetRandomCardsByTier(tier, count));
     }
 
     private void RemoveCurrentStarterCards()

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -56,7 +56,7 @@ public class StartDeckManager : MonoBehaviour
 
         currentStarterCards.Clear();
         currentStarterCards.AddRange(starterCards);
-        uiCardPanel.SetCards(starterCards);
+        uiCardPanel?.SetCards(starterCards);
     }
 
     private List<GameObject> GenerateStarterCards(CardRandomizerManager randomizer)

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -45,13 +45,14 @@ public class StartDeckManager : MonoBehaviour
     private void DealStarterCards()
     {
         CardRandomizerManager randomizer = CardRandomizerManager.Instance;
-        if (randomizer == null) return;
+        PlayerState playerState = PlayerState.Instance;
+        if (randomizer == null || playerState == null) return;
 
         List<GameObject> starterCards = GenerateStarterCards(randomizer);
 
         foreach (var card in starterCards)
         {
-            PlayerState.Instance?.AddCard(card);
+            playerState.AddCard(card);
         }
 
         currentStarterCards.Clear();

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -6,7 +6,7 @@ public class StartDeckManager : MonoBehaviour
 {
     [SerializeField] private UICardPanel uiCardPanel;
     [SerializeField] private Button rerollButton;
-    [SerializeField] private int commonCardCount = 2;
+    [SerializeField] private int commonCardCount = 4;
     [SerializeField] private int uncommonCardCount = 2;
     [SerializeField] private int uniqueCardCount = 1;
     [SerializeField] private float rerollCardInterval = 0.12f;

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -107,14 +107,13 @@ public class StartDeckManager : MonoBehaviour
     {
         if (rerollButton != null) return;
 
-        Button[] buttons = GetComponentsInChildren<Button>(true);
-        foreach (Button button in buttons)
+        StartDeckRerollButton marker = GetComponentInChildren<StartDeckRerollButton>(true);
+        if (marker != null)
         {
-            if (button.name == "RerollButton")
-            {
-                rerollButton = button;
-                return;
-            }
+            rerollButton = marker.Button;
+            return;
         }
+
+        Debug.LogWarning($"{nameof(StartDeckManager)}에 {nameof(rerollButton)} 참조가 연결되지 않았습니다.", this);
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -1,28 +1,128 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class StartDeckManager : MonoBehaviour
 {
     [SerializeField] private UICardPanel uiCardPanel;
+    [SerializeField] private Button rerollButton;
     [SerializeField] private int commonCardCount = 2;
     [SerializeField] private int uncommonCardCount = 1;
     [SerializeField] private int uniqueCardCount = 1;
+    [SerializeField] private float rerollCardInterval = 0.12f;
+    [SerializeField] private float rerollAnimationDurationMultiplier = 0.45f;
+
+    private readonly List<GameObject> currentStarterCards = new List<GameObject>();
+
+    private void OnEnable()
+    {
+        if (uiCardPanel != null)
+            uiCardPanel.CardSequenceCompleted += EnableRerollButton;
+    }
+
+    private void OnDisable()
+    {
+        if (uiCardPanel != null)
+            uiCardPanel.CardSequenceCompleted -= EnableRerollButton;
+    }
 
     public void Init()
+    {
+        CacheRerollButton();
+        SetRerollButtonInteractable(false);
+        RemoveCurrentStarterCards();
+        DealStarterCards(null);
+    }
+
+    public void Reroll()
+    {
+        SetRerollButtonInteractable(false);
+        List<GameObject> previousCards = new List<GameObject>(currentStarterCards);
+        RemoveCurrentStarterCards();
+        DealStarterCards(previousCards);
+        uiCardPanel?.RefreshCards(rerollCardInterval, rerollAnimationDurationMultiplier);
+    }
+
+    private void DealStarterCards(List<GameObject> excludedCards)
     {
         CardRandomizerManager randomizer = CardRandomizerManager.Instance;
         if (randomizer == null) return;
 
-        List<GameObject> starterCards = new List<GameObject>();
-        starterCards.AddRange(randomizer.GetRandomCardsByTier(Tier.Common, commonCardCount));
-        starterCards.AddRange(randomizer.GetRandomCardsByTier(Tier.Uncommon, uncommonCardCount));
-        starterCards.AddRange(randomizer.GetRandomCardsByTier(Tier.Unique, uniqueCardCount));
+        List<GameObject> starterCards = GenerateStarterCards(randomizer, excludedCards);
 
         foreach (var card in starterCards)
         {
             PlayerState.Instance?.AddCard(card);
         }
 
+        currentStarterCards.Clear();
+        currentStarterCards.AddRange(starterCards);
         uiCardPanel.SetCards(starterCards);
+    }
+
+    private List<GameObject> GenerateStarterCards(CardRandomizerManager randomizer, List<GameObject> excludedCards)
+    {
+        List<GameObject> starterCards = new List<GameObject>();
+        AddCardsByTier(starterCards, randomizer, Tier.Common, commonCardCount, excludedCards);
+        AddCardsByTier(starterCards, randomizer, Tier.Uncommon, uncommonCardCount, excludedCards);
+        AddCardsByTier(starterCards, randomizer, Tier.Unique, uniqueCardCount, excludedCards);
+        return starterCards;
+    }
+
+    private void AddCardsByTier(
+        List<GameObject> destination,
+        CardRandomizerManager randomizer,
+        Tier tier,
+        int count,
+        List<GameObject> excludedCards)
+    {
+        if (count <= 0) return;
+
+        List<GameObject> pickedCards = randomizer.GetRandomCardsByTier(tier, count, excludedCards);
+        if (pickedCards.Count < count && excludedCards != null && excludedCards.Count > 0)
+        {
+            pickedCards.AddRange(randomizer.GetRandomCardsByTier(tier, count - pickedCards.Count, pickedCards));
+        }
+
+        destination.AddRange(pickedCards);
+    }
+
+    private void RemoveCurrentStarterCards()
+    {
+        if (PlayerState.Instance == null) return;
+
+        foreach (GameObject card in currentStarterCards)
+        {
+            PlayerState.Instance.RemoveCard(card);
+        }
+
+        currentStarterCards.Clear();
+    }
+
+    private void EnableRerollButton()
+    {
+        SetRerollButtonInteractable(true);
+    }
+
+    private void SetRerollButtonInteractable(bool interactable)
+    {
+        CacheRerollButton();
+        if (rerollButton != null)
+            rerollButton.interactable = interactable;
+    }
+
+    private void CacheRerollButton()
+    {
+        if (rerollButton != null) return;
+
+        Button[] buttons = GetComponentsInChildren<Button>(true);
+        foreach (Button button in buttons)
+        {
+            if (button.name == "RerollButton")
+            {
+                rerollButton = button;
+                return;
+            }
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/StartDeckManager.cs
@@ -7,7 +7,7 @@ public class StartDeckManager : MonoBehaviour
     [SerializeField] private UICardPanel uiCardPanel;
     [SerializeField] private Button rerollButton;
     [SerializeField] private int commonCardCount = 2;
-    [SerializeField] private int uncommonCardCount = 1;
+    [SerializeField] private int uncommonCardCount = 2;
     [SerializeField] private int uniqueCardCount = 1;
     [SerializeField] private float rerollCardInterval = 0.12f;
     [SerializeField] private float rerollAnimationDurationMultiplier = 0.45f;

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardAnim.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardAnim.cs
@@ -16,6 +16,7 @@ public class UICardAnim : MonoBehaviour
     private CanvasGroup canvasGroup;
     private RectTransform rt;
     private float originalWidth;
+    public float Duration => duration;
 
     [SerializeField] private GameObject cardPrefab;
     public GameObject CardPreFab { get { return cardPrefab; } set { cardPrefab = value; } }
@@ -40,12 +41,23 @@ public class UICardAnim : MonoBehaviour
         gameObject.SetActive(false);
     }
 
-    public void CardAnimation()
+    public void CardAnimation(float durationMultiplier = 1f)
     {
+        float adjustedDuration = Mathf.Max(0.01f, duration * durationMultiplier);
+        float adjustedFadeDuration = Mathf.Max(0.01f, fadeDuration * durationMultiplier);
+
+        rt.DOKill();
+        canvasGroup.DOKill();
+        cardSprite.rectTransform.DOKill();
+
+        rt.sizeDelta = new Vector2(0f, rt.sizeDelta.y);
+        canvasGroup.alpha = 0f;
+        cardSprite.rectTransform.anchoredPosition = new Vector3(0, startYPos, 0);
+
         DOTween.Sequence()
-            .Append(rt.DOSizeDelta(new Vector2(originalWidth, rt.sizeDelta.y), fadeDuration).SetEase(enableEase))
-            .Join(canvasGroup.DOFade(1f, fadeDuration).SetEase(enableEase))
-            .Join(cardSprite.rectTransform.DOAnchorPosY(0f, duration).SetEase(enableEase));
+            .Append(rt.DOSizeDelta(new Vector2(originalWidth, rt.sizeDelta.y), adjustedFadeDuration).SetEase(enableEase))
+            .Join(canvasGroup.DOFade(1f, adjustedFadeDuration).SetEase(enableEase))
+            .Join(cardSprite.rectTransform.DOAnchorPosY(0f, adjustedDuration).SetEase(enableEase));
 
         if (cardPrefab != null)
         {

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardPanel.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System;
 using DG.Tweening;
 using UnityEngine;
 
 public class UICardPanel : ButtonPanel
 {
+    public event Action CardSequenceCompleted;
+
     public UICardAnim[] anims;
     public int cardCount;
 
@@ -31,6 +34,18 @@ public class UICardPanel : ButtonPanel
         base.DisablePanel();
     }
 
+    public void RefreshCards()
+    {
+        PrepareCards();
+        PlayCardSequence();
+    }
+
+    public void RefreshCards(float intervalOverride, float animationDurationMultiplier)
+    {
+        PrepareCards();
+        PlayCardSequence(intervalOverride, animationDurationMultiplier);
+    }
+
     private void PrepareCards()
     {
         cardCount = cards.Count;
@@ -48,21 +63,31 @@ public class UICardPanel : ButtonPanel
         }
     }
 
-    private void PlayCardSequence()
+    private void PlayCardSequence(float intervalOverride = -1f, float animationDurationMultiplier = 1f)
     {
         cardSequence?.Kill();
         cardSequence = DOTween.Sequence();
 
-        for (int i = 0; i < cardCount; i++)
+        int count = Mathf.Min(cardCount, anims.Length);
+        float interval = intervalOverride >= 0f ? intervalOverride : cardInterval;
+        float lastAnimationDuration = 0f;
+
+        for (int i = 0; i < count; i++)
         {
             int index = i;
             cardSequence.AppendCallback(() =>
             {
                 anims[index].gameObject.SetActive(true);
-                anims[index].CardAnimation();
+                anims[index].CardAnimation(animationDurationMultiplier);
             });
-            cardSequence.AppendInterval(cardInterval);
+
+            lastAnimationDuration = Mathf.Max(0f, anims[index].Duration * animationDurationMultiplier);
+            if (i < count - 1)
+                cardSequence.AppendInterval(interval);
         }
+
+        cardSequence.AppendInterval(lastAnimationDuration);
+        cardSequence.AppendCallback(() => CardSequenceCompleted?.Invoke());
 
         if (panelCloseDelay >= 0f)
         {

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/UICardPanel.cs
@@ -50,15 +50,20 @@ public class UICardPanel : ButtonPanel
     {
         cardCount = cards.Count;
         UICardAnim[] uiCards = anims;
+        if (uiCards == null) return;
 
         for (int i = 0; i < uiCards.Length; i++)
         {
+            if (uiCards[i] == null) continue;
+
             uiCards[i].gameObject.SetActive(false);
         }
 
         int count = Mathf.Min(cardCount, uiCards.Length);
         for (int i = 0; i < count; i++)
         {
+            if (uiCards[i] == null) continue;
+
             uiCards[i].CardPreFab = cards[i];
         }
     }
@@ -67,6 +72,11 @@ public class UICardPanel : ButtonPanel
     {
         cardSequence?.Kill();
         cardSequence = DOTween.Sequence();
+        if (anims == null)
+        {
+            cardSequence.AppendCallback(() => CardSequenceCompleted?.Invoke());
+            return;
+        }
 
         int count = Mathf.Min(cardCount, anims.Length);
         float interval = intervalOverride >= 0f ? intervalOverride : cardInterval;
@@ -74,14 +84,16 @@ public class UICardPanel : ButtonPanel
 
         for (int i = 0; i < count; i++)
         {
-            int index = i;
+            UICardAnim anim = anims[i];
+            if (anim == null) continue;
+
             cardSequence.AppendCallback(() =>
             {
-                anims[index].gameObject.SetActive(true);
-                anims[index].CardAnimation(animationDurationMultiplier);
+                anim.gameObject.SetActive(true);
+                anim.CardAnimation(animationDurationMultiplier);
             });
 
-            lastAnimationDuration = Mathf.Max(0f, anims[index].Duration * animationDurationMultiplier);
+            lastAnimationDuration = Mathf.Max(0f, anim.Duration * animationDurationMultiplier);
             if (i < count - 1)
                 cardSequence.AppendInterval(interval);
         }


### PR DESCRIPTION
## 개요
시작 카드 보상 구성을 확장하고, 시작 카드 전체를 다시 뽑을 수 있는 리롤 기능을 추가했습니다.

## 변경 사항

- 시작 카드 지급 개수를 4장에서 5장으로 확장
- 시작 카드 구성 변경
  - 일반 카드 2장
  - 희귀 카드 2장
  - 고급 카드 1장
- 시작 보상 UI에 리롤 버튼 추가
- 리롤 시 현재 지급된 시작 카드 전체를 제거하고 새 카드 목록으로 교체
- 리롤 직후 카드 공개 애니메이션 재생
- 카드가 모두 공개되기 전에는 리롤 버튼을 누를 수 없도록 제한
- 시작 카드 5장 표시에 맞춰 카드 UI 크기 및 배치 조정