### PR TITLE
[Fix] 카드 입력 및 효과 문제 수정, 상태 추적 로그 추가

### DIFF
--- a/ChaosChess_v2/Assets/Prefab/CardUI/ActiveEffectCardExample.prefab
+++ b/ChaosChess_v2/Assets/Prefab/CardUI/ActiveEffectCardExample.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uB0A8\uC740 \uD134"
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
   m_sharedMaterial: {fileID: 2683479388609967759, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
@@ -92,8 +92,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60
-  m_fontSizeBase: 60
+  m_fontSize: 48
+  m_fontSizeBase: 48
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -279,8 +279,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -59.999985}
+  m_SizeDelta: {x: 0, y: -120.00003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4695047292731171162
 CanvasRenderer:

--- a/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
+++ b/ChaosChess_v2/Assets/Script/Arena/ArenaManager.cs
@@ -178,7 +178,6 @@ public class ArenaManager : MonoBehaviour
     {
         if (!isArenaActive) return;
         isArenaActive = false;
-        cardHandLayout?.SetArenaInputBlocked(false);
 
         GameManager gm = GameManager.Instance;
         gm.PopCardIntervalPause();
@@ -187,6 +186,7 @@ public class ArenaManager : MonoBehaviour
         // 이벤트 구독 해제 및 투기장 모드 비활성화
         gm.OnHalfTurnChanged -= OnHalfTurnChanged;
         gm.IsArenaMode = false;
+        cardHandLayout?.SetArenaInputBlocked(false);
         gm.SetLockedPiece(null);
         ArenaEnded?.Invoke();
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/AgileCard.cs
@@ -24,7 +24,7 @@ public class AgileCard : CardData, IPieceCard
         Piece pawn = args.Targets[0];
         AgileEffect effect = CreatePieceEffector<AgileEffect>(pawn);
 
-        effect.Apply();
+        effect.Apply(true);
     }
 }
 
@@ -45,6 +45,11 @@ public class AgileEffect : PieceEffector, IMovementOverrideEffect
     }
 
     public override void OnPieceCapture()
+    {
+        Revert();
+    }
+
+    protected override void OnHalfTurnChanged()
     {
         Revert();
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -27,8 +27,7 @@ public class CobwebCard : CardData, ITileCard
         Vector3Int pos = args.TargetPos[0];
 
         CobwebEffector effect = CreateGlobalEffector<CobwebEffector>();
-        effect.TilePos = pos;
-        effect.DataSO = DataSO;
+        effect.InitCobweb(pos, DataSO);
         effect.Apply();
     }
 }
@@ -40,6 +39,13 @@ public class CobwebEffector : GlobalEffector
     private bool isTriggered = false;
 
     public Vector3Int TilePos;
+
+    public void InitCobweb(Vector3Int tilePos, CardDataSO dataSO)
+    {
+        TilePos = tilePos;
+        DataSO = dataSO;
+        SetDuration(-1);
+    }
 
     protected override void OnApply()
     {

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -34,8 +34,6 @@ public class CobwebCard : CardData, ITileCard
 
 public class CobwebEffector : GlobalEffector
 {
-    public CardDataSO DataSO;
-
     private bool isTriggered = false;
 
     public Vector3Int TilePos;
@@ -43,21 +41,21 @@ public class CobwebEffector : GlobalEffector
     public void InitCobweb(Vector3Int tilePos, CardDataSO dataSO)
     {
         TilePos = tilePos;
-        DataSO = dataSO;
+        CardSO = dataSO;
         SetDuration(-1);
     }
 
     protected override void OnApply()
     {
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(TilePos, DataSO, 0, RemainingTurns);
+        if (CardSO.NeedEffectTileBase)
+            BoardManager.Instance.TileEffectDrawer.SetTileEffect(TilePos, CardSO, 0, RemainingTurns);
 
         BoardManager.Instance.RegisterGlobalEffector(this);
     }
 
     protected override void OnRevert()
     {
-        if (DataSO.NeedEffectTileBase)
+        if (CardSO.NeedEffectTileBase)
             BoardManager.Instance.TileEffectDrawer.ClearTileEffect(TilePos);
 
         BoardManager.Instance.UnregisterGlobalEffector(this);
@@ -142,7 +140,7 @@ public class CobwebEffector : GlobalEffector
 
         CobwebPieceEffector pieceEffect = piece.gameObject.AddComponent<CobwebPieceEffector>();
         pieceEffect.CardSO = null;
-        pieceEffect.Init(piece, DataSO.LimitTurn);
+        pieceEffect.Init(piece, CardSO.LimitTurn);
         pieceEffect.Apply();
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/DemocracyCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/DemocracyCard.cs
@@ -10,6 +10,8 @@ public class DemocracyCard : CardData, ICard
 {
     public void Execute(CardEffectArgs args = null)
     {
+        Debug.Log("[Democracy] Card executed.");
+
         DemocracyEffect effect =
             CreateGlobalEffector<DemocracyEffect>();
 
@@ -27,6 +29,7 @@ public class DemocracyEffect : GlobalEffector
 
     protected override void OnRevert()
     {
+        Debug.Log("[Democracy] Effect reverted.");
         GameManager.Instance.OnTurnChanged -= CheckCondition;
         Destroy(gameObject);
     }
@@ -60,6 +63,7 @@ public class DemocracyEffect : GlobalEffector
 
         if (pawnCount >= 2 * otherCount)
         {
+            Debug.Log($"[Democracy] Condition met: Pawns={pawnCount}, Others={otherCount}");
             GameManager.Instance.OnSurrender(GameManager.Instance.EnemyColor);
             Revert();
         }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -98,15 +98,20 @@ public class ActiveEffectCardDisplay : MonoBehaviour
         CardDataSO cardSO = effector.CardSO;
         if (cardSO == null) return;
 
+        bool isNewCard = false;
         if (!cards.TryGetValue(cardSO, out ActiveEffectCard card))
         {
             card = CreateCard(cardSO);
             cards.Add(cardSO, card);
+            isNewCard = true;
         }
 
         card.Effects.Add(effector);
         UpdateCard(card);
         RefreshTrayState();
+
+        if (isNewCard)
+            card.CardUI?.PlayAppearAnimation();
     }
 
     private void CleanUpDestroyedEffects()
@@ -146,8 +151,22 @@ public class ActiveEffectCardDisplay : MonoBehaviour
         card.Effects.Remove(effector);
         if (card.Effects.Count == 0)
         {
-            Destroy(card.Root);
             cards.Remove(cardSO);
+            if (card.CardUI != null)
+            {
+                card.CardUI.PlayDisappearAnimation(() =>
+                {
+                    Destroy(card.Root);
+                    RefreshTrayState();
+                });
+            }
+            else
+            {
+                Destroy(card.Root);
+                RefreshTrayState();
+            }
+
+            return;
         }
         else
         {
@@ -176,6 +195,7 @@ public class ActiveEffectCardDisplay : MonoBehaviour
             statusTextSettings.Format(ActiveEffectStatusType.TurnBased, remainingTurns));
         isArenaCardDisplayed = true;
         RefreshTrayState();
+        arenaCard.CardUI?.PlayAppearAnimation();
     }
 
     private void HandleArenaRemainingTurnsChanged(int remainingTurns)
@@ -190,12 +210,25 @@ public class ActiveEffectCardDisplay : MonoBehaviour
         if (!isArenaCardDisplayed) return;
 
         RemoveArenaCard();
-        RefreshTrayState();
     }
 
     private void RemoveArenaCard()
     {
-        Destroy(arenaCard.Root);
+        GameObject root = arenaCard.Root;
+        if (arenaCard.CardUI != null)
+        {
+            arenaCard.CardUI.PlayDisappearAnimation(() =>
+            {
+                Destroy(root);
+                RefreshTrayState();
+            });
+        }
+        else
+        {
+            Destroy(root);
+            RefreshTrayState();
+        }
+
         arenaCard = null;
         isArenaCardDisplayed = false;
     }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -149,6 +149,8 @@ public class ActiveEffectCardDisplay : MonoBehaviour
         if (!cards.TryGetValue(cardSO, out ActiveEffectCard card)) return;
 
         card.Effects.Remove(effector);
+        Debug.Log($"[ActiveEffectUI] {cardSO.CardName} 제거, 남은 효과: {card.Effects.Count}");
+
         if (card.Effects.Count == 0)
         {
             cards.Remove(cardSO);

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -246,7 +246,7 @@ public class ActiveEffectCardDisplay : MonoBehaviour
             if (cardSO != null)
                 cardUI.CardImage.sprite = cardSO.CardImage;
 
-            cardUI.Title.text = fallbackTitle;
+            cardUI.Title.text = fallbackTitle ?? cardSO?.CardName;
             cardUI.RemainTurn.text = status ?? statusTextSettings.Format(ActiveEffectStatusType.Active);
         }
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
@@ -27,7 +27,10 @@ public class CardHandLayout : MonoBehaviour
     private void OnDisable()
     {
         if (isSubscribed && gameManager != null)
+        {
             gameManager.OnPlayerCheckStateChanged -= SetInputBlocked;
+            gameManager.OnHalfTurnChanged -= UpdateTurnInputBlocked;
+        }
 
         isSubscribed = false;
     }
@@ -58,8 +61,14 @@ public class CardHandLayout : MonoBehaviour
             return;
 
         gameManager.OnPlayerCheckStateChanged += SetInputBlocked;
+        gameManager.OnHalfTurnChanged += UpdateTurnInputBlocked;
         isSubscribed = true;
-        SetInputBlocked(gameManager.IsPlayerInCheck);
+        UpdateTurnInputBlocked();
+    }
+
+    private void UpdateTurnInputBlocked()
+    {
+        SetInputBlocked(gameManager.IsPlayerInCheck || !gameManager.IsPlayerTurn);
     }
 
     private void SetInputBlocked(bool isBlocked)

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
@@ -28,7 +28,7 @@ public class CardHandLayout : MonoBehaviour
     {
         if (isSubscribed && gameManager != null)
         {
-            gameManager.OnPlayerCheckStateChanged -= SetInputBlocked;
+            gameManager.OnPlayerCheckStateChanged -= UpdateTurnInputBlocked;
             gameManager.OnHalfTurnChanged -= UpdateTurnInputBlocked;
         }
 
@@ -60,14 +60,19 @@ public class CardHandLayout : MonoBehaviour
         if (gameManager == null)
             return;
 
-        gameManager.OnPlayerCheckStateChanged += SetInputBlocked;
+        gameManager.OnPlayerCheckStateChanged += UpdateTurnInputBlocked;
         gameManager.OnHalfTurnChanged += UpdateTurnInputBlocked;
         isSubscribed = true;
         UpdateTurnInputBlocked();
     }
 
+    private void UpdateTurnInputBlocked(bool _) => UpdateTurnInputBlocked();
+
     private void UpdateTurnInputBlocked()
     {
+        if (gameManager.IsArenaMode)
+            return;
+
         SetInputBlocked(gameManager.IsPlayerInCheck || !gameManager.IsPlayerTurn);
     }
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
@@ -49,7 +49,13 @@ public class CardHandLayout : MonoBehaviour
 
     public void RefreshAnimated() => Refresh(animate: true);
 
-    public void SetArenaInputBlocked(bool isBlocked) => SetInputBlocked(isBlocked);
+    public void SetArenaInputBlocked(bool isBlocked)
+    {
+        SetInputBlocked(isBlocked);
+
+        if (!isBlocked)
+            UpdateTurnInputBlocked();
+    }
 
     private void SubscribeGameManager()
     {


### PR DESCRIPTION
## 개요

상대 턴일때 카드 사용을 차단하고, 거미줄과 민첩 카드의 지속 효과 오류를 수정했습니다.
활성화 카드 UI와 민주주의 카드 재등장 문제를 추적하기 위한 디버그 로그도 추가했습니다.

## 변경 사항

### 카드 로직 수정

- 거미줄 카드
  - 지속 시간을 무제한으로 초기화하도록 수정했습니다.
  - 효과가 의도치 않게 자동 해제되던 문제를 해결했습니다.

- 민첩 카드
  - 반 턴 후에 효과가 해제되도록 수정했습니다.
  - 대상 기물이 잡힐 때 즉시 해제되는 기존 동작은 유지했습니다.

### 상대 턴 카드 사용 차단

- 상대방 턴에는 카드를 사용할 수 없도록 입력을 차단했습니다.
- 투기장 입력 차단과 턴 입력 차단이 중첩되어도 정상적으로 유지되도록 수정했습니다.

### 활성화 카드 UI 및 디버그

- 카드 효과 적용·해제에 맞춰 활성화 카드 UI가 표시·제거되도록 연결했습니다.
- 활성화 카드 UI가 의도치 않게 사라지는 원인을 추적할 수 있도록 관련 로그를 추가했습니다.
- 민주주의 카드의 사용, 조건 충족 및 효과 해제 시점을 확인할 수 있도록 로그를 추가했습니다.

## 관련 이슈

- #200 
  - 상대턴일때 카드를 못 사용하게 입력을 차단했습니다.

- #203  
  - 카드 사용, 조건 충족, 효과 해제 시점을 기록하여 카드가 다시 덱에 들어오는 원인을 추적할 수 있도록 했습니다.

- #204
  - 효과 적용·해제와 UI 활성화·비활성화에 애니메이션 문제를 해결했습니다
  - UI 자동 삭제 흐름을 확인할 수 있는 디버그 로그를 추가했습니다.
