### PR TITLE
[Feature] 보상 카드 티어별 지급 확률 적용

### DIFF
--- a/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/CardRandomizerManager.cs
@@ -139,6 +139,36 @@ public class CardRandomizerManager : MonoBehaviour
             .ToList();
     }
 
+    public bool TryGetRandomCardByTier(
+        Tier tier,
+        HashSet<GameObject> excludedCards,
+        out GameObject selectedCard)
+    {
+        selectedCard = null;
+        int candidateCount = 0;
+
+        foreach (GameObject card in allCards)
+        {
+            if (card == null || excludedCards.Contains(card))
+                continue;
+
+            CardData data = card.GetComponent<CardData>();
+            if (data == null ||
+                data.DataSO == null ||
+                data.DataSO.CardTier != tier ||
+                IsCardActive(data.DataSO))
+            {
+                continue;
+            }
+
+            candidateCount++;
+            if (Random.Range(0, candidateCount) == 0)
+                selectedCard = card;
+        }
+
+        return selectedCard != null;
+    }
+
     private void Shuffle(List<GameObject> list)
     {
         for (int i = list.Count - 1; i > 0; i--)

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/CardRewardManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/CardRewardManager.cs
@@ -4,6 +4,15 @@ using UnityEngine;
 
 public class CardRewardManager : MonoBehaviour
 {
+    private static readonly Tier[] AllTiers =
+    {
+        Tier.Common,
+        Tier.Uncommon,
+        Tier.Unique,
+        Tier.Rare,
+        Tier.Legendary
+    };
+
     [SerializeField] private UICardPanel uiCardPanel;
     [SerializeField] private TextMeshProUGUI cardRewardText;
 
@@ -44,14 +53,7 @@ public class CardRewardManager : MonoBehaviour
 
         for (int i = 0; i < count; i++)
         {
-            List<Tier> availableTiers = new List<Tier>
-            {
-                Tier.Common,
-                Tier.Uncommon,
-                Tier.Unique,
-                Tier.Rare,
-                Tier.Legendary
-            };
+            List<Tier> availableTiers = new List<Tier>(AllTiers);
 
             while (availableTiers.Count > 0)
             {

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/CardRewardManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/CardRewardManager.cs
@@ -7,6 +7,13 @@ public class CardRewardManager : MonoBehaviour
     [SerializeField] private UICardPanel uiCardPanel;
     [SerializeField] private TextMeshProUGUI cardRewardText;
 
+    [Header("Tier Weights")]
+    [SerializeField, Min(0f)] private float commonWeight = 50f;
+    [SerializeField, Min(0f)] private float uncommonWeight = 25f;
+    [SerializeField, Min(0f)] private float uniqueWeight = 15f;
+    [SerializeField, Min(0f)] private float rareWeight = 8f;
+    [SerializeField, Min(0f)] private float legendaryWeight = 2f;
+
     private void Start()
     {
         if (PlayerState.Instance == null || CardRandomizerManager.Instance == null)
@@ -17,8 +24,7 @@ public class CardRewardManager : MonoBehaviour
             return;
 
         List<GameObject> ownedCards = new List<GameObject>(PlayerState.Instance.CardPool);
-        List<GameObject> rewardCards =
-            CardRandomizerManager.Instance.GetRandomCardsFromAll(ownedCards, rewardCardCount);
+        List<GameObject> rewardCards = GetRewardCards(ownedCards, rewardCardCount);
 
         foreach (var card in rewardCards)
         {
@@ -29,6 +35,87 @@ public class CardRewardManager : MonoBehaviour
 
         if (cardRewardText != null)
             cardRewardText.text = $"카드 {rewardCardCount}개 얻기";
+    }
+
+    private List<GameObject> GetRewardCards(List<GameObject> ownedCards, int count)
+    {
+        List<GameObject> rewardCards = new List<GameObject>();
+        HashSet<GameObject> excludedCards = new HashSet<GameObject>(ownedCards);
+
+        for (int i = 0; i < count; i++)
+        {
+            List<Tier> availableTiers = new List<Tier>
+            {
+                Tier.Common,
+                Tier.Uncommon,
+                Tier.Unique,
+                Tier.Rare,
+                Tier.Legendary
+            };
+
+            while (availableTiers.Count > 0)
+            {
+                Tier tier = RollTier(availableTiers);
+                if (CardRandomizerManager.Instance.TryGetRandomCardByTier(
+                        tier,
+                        excludedCards,
+                        out GameObject card))
+                {
+                    rewardCards.Add(card);
+                    excludedCards.Add(card);
+                    break;
+                }
+
+                availableTiers.Remove(tier);
+            }
+        }
+
+        return rewardCards;
+    }
+
+    private Tier RollTier(List<Tier> availableTiers)
+    {
+        float totalWeight = 0f;
+        foreach (Tier tier in availableTiers)
+        {
+            totalWeight += GetTierWeight(tier);
+        }
+
+        // 모든 가중치가 0이거나 음수인 경우, 확률을 동일하게 설정 후 반환
+        if (totalWeight <= 0f)
+            return availableTiers[Random.Range(0, availableTiers.Count)];
+
+
+        float roll = Random.value * totalWeight;
+        float cumulativeWeight = 0f;
+        Tier selectedTier = availableTiers[0];
+
+        foreach (Tier tier in availableTiers)
+        {
+            float weight = GetTierWeight(tier);
+            if (weight <= 0f)
+                continue;
+
+            selectedTier = tier;
+            cumulativeWeight += weight;
+            if (roll < cumulativeWeight)
+                break;
+        }
+
+        return selectedTier;
+    }
+
+    private float GetTierWeight(Tier tier)
+    {
+        return tier switch
+        {
+            Tier.Common => commonWeight,
+            Tier.Uncommon => uncommonWeight,
+            Tier.Unique => uniqueWeight,
+            Tier.Rare => rareWeight,
+            Tier.Legendary => legendaryWeight,
+            _ => 0f
+        };
     }
 
     private int ResolveRewardCardCount()


### PR DESCRIPTION
## 개요
보상 카드 지급 시 티어별 확률을 적용했습니다.

## 변경 사항
- 티어별 보상 등장 가중치 추가
- 선택된 티어에서 보유하지 않은 카드 추첨
- 지급 가능한 카드가 없는 티어 재추첨