### PR TITLE
[Fix] 씬 전환 BGM 페이드 타이밍 개선

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -3569,7 +3569,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 7300149731203480330, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 8300000, guid: 7f468940c865f2d459e94bd8241407c9, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 1

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -33941,7 +33941,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 7300149731203480330, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 8300000, guid: 747f40fb6e16c7d4388be48e6a771cce, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 1

--- a/ChaosChess_v2/Assets/Script/SoundManager.cs
+++ b/ChaosChess_v2/Assets/Script/SoundManager.cs
@@ -62,6 +62,18 @@ public class SoundManager : MonoBehaviour
 
         MuteBGM(GetBGMMute());
         MuteSFX(GetSFXMute());
+        PlayInitialBGM();
+    }
+
+    private void PlayInitialBGM()
+    {
+        if (bgmSource == null || bgmSource.clip == null || bgmSource.isPlaying)
+            return;
+
+        bgmSource.loop = true;
+        bgmSource.volume = 0f;
+        bgmSource.Play();
+        BgFadeIn(SceneBgmFadeDuration);
     }
 
     // ── BGM 재생 제어 ──────────────────────────────────────

--- a/ChaosChess_v2/Assets/Script/SoundManager.cs
+++ b/ChaosChess_v2/Assets/Script/SoundManager.cs
@@ -157,23 +157,23 @@ public class SoundManager : MonoBehaviour
         return bgmSource != null && sceneBgmClip != null && bgmSource.clip != sceneBgmClip;
     }
 
-    public Tween BeginSceneTransitionFadeOut(string sceneName, bool forceFade = false, float duration = -1f)
+    public Tween BeginSceneTransitionFadeOut(string sceneName, bool forceFade = false, float? duration = null)
     {
         if (!forceFade && !ShouldTransitionBGM(sceneName))
             return null;
 
-        return BgFadeOut(duration >= 0f ? duration : SceneBgmFadeDuration);
+        return BgFadeOut(duration ?? SceneBgmFadeDuration);
     }
 
-    public void ApplySceneBGM(string sceneName, bool restart = false, float duration = -1f)
+    public void ApplySceneBGM(string sceneName, bool restart = false, float? duration = null)
     {
         AudioClip sceneBgmClip = GetSceneBGM(sceneName);
         if (bgmSource == null || sceneBgmClip == null)
             return;
 
-        float fadeDuration = duration >= 0f ? duration : SceneBgmFadeDuration;
+        float fadeDuration = duration ?? SceneBgmFadeDuration;
 
-        if (bgmSource != null && bgmSource.clip == sceneBgmClip && !restart)
+        if (bgmSource.clip == sceneBgmClip && !restart)
         {
             if (!bgmSource.isPlaying)
                 bgmSource.Play();

--- a/ChaosChess_v2/Assets/Script/SoundManager.cs
+++ b/ChaosChess_v2/Assets/Script/SoundManager.cs
@@ -157,21 +157,45 @@ public class SoundManager : MonoBehaviour
         return bgmSource != null && sceneBgmClip != null && bgmSource.clip != sceneBgmClip;
     }
 
-    public void BeginSceneTransitionFadeOut(string sceneName)
+    public Tween BeginSceneTransitionFadeOut(string sceneName, bool forceFade = false, float duration = -1f)
     {
-        if (!ShouldTransitionBGM(sceneName))
-            return;
+        if (!forceFade && !ShouldTransitionBGM(sceneName))
+            return null;
 
-        BgFadeOut(SceneBgmFadeDuration);
+        return BgFadeOut(duration >= 0f ? duration : SceneBgmFadeDuration);
     }
 
-    public void ApplySceneBGM(string sceneName)
+    public void ApplySceneBGM(string sceneName, bool restart = false, float duration = -1f)
     {
         AudioClip sceneBgmClip = GetSceneBGM(sceneName);
-        if (sceneBgmClip == null)
+        if (bgmSource == null || sceneBgmClip == null)
             return;
 
-        SwitchBGM(sceneBgmClip, SceneBgmFadeDuration, false);
+        float fadeDuration = duration >= 0f ? duration : SceneBgmFadeDuration;
+
+        if (bgmSource != null && bgmSource.clip == sceneBgmClip && !restart)
+        {
+            if (!bgmSource.isPlaying)
+                bgmSource.Play();
+
+            BgFadeIn(fadeDuration);
+            return;
+        }
+
+        if (restart)
+        {
+            bgmFadeTween?.Kill();
+            bgmSource.Stop();
+            bgmSource.clip = sceneBgmClip;
+            bgmSource.loop = true;
+            bgmSource.time = 0f;
+            bgmSource.volume = 0f;
+            bgmSource.Play();
+            BgFadeIn(fadeDuration);
+            return;
+        }
+
+        SwitchBGM(sceneBgmClip, fadeDuration, false);
     }
 
     private AudioClip GetSceneBGM(string sceneName)
@@ -196,13 +220,14 @@ public class SoundManager : MonoBehaviour
         bgmFadeTween = bgmSource.DOFade(1f, Mathf.Max(0f, duration)).SetUpdate(true);
     }
 
-    public void BgFadeOut(float duration = 0.8f)
+    public Tween BgFadeOut(float duration = 0.8f)
     {
         if (bgmSource == null)
-            return;
+            return null;
 
         bgmFadeTween?.Kill();
         bgmFadeTween = bgmSource.DOFade(0f, Mathf.Max(0f, duration)).SetUpdate(true);
+        return bgmFadeTween;
     }
 
     // ── BGM 페이드 (외부 AudioSource 사용, 기존 오버로드 유지) ──

--- a/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
@@ -6,6 +6,7 @@ using UnityEngine.SceneManagement;
 public class SceneLoadManager : MonoBehaviour
 {
     [SerializeField] private float fadeDuration = 0.18f;
+    [SerializeField] private float bgmFadeDuration = 0.8f;
     [SerializeField] private float loadingDisplayDelay = 0.25f;
 
     private static SceneLoadManager instance;
@@ -53,8 +54,13 @@ public class SceneLoadManager : MonoBehaviour
         isLoading = true;
 
         SoundManager soundManager = SoundManager.Instance;
-        bool transitionBgm = soundManager != null && soundManager.ShouldTransitionBGM(sceneName);
-        soundManager?.BeginSceneTransitionFadeOut(sceneName);
+        bool forceBgmFade = SceneManager.GetActiveScene().name == "ResultScene" && sceneName == "MainScene";
+        bool transitionBgm = soundManager != null &&
+                             (forceBgmFade || soundManager.ShouldTransitionBGM(sceneName));
+        Tween bgmFadeOut = soundManager?.BeginSceneTransitionFadeOut(
+            sceneName,
+            forceBgmFade,
+            bgmFadeDuration);
 
         if (transitionBgm)
             yield return null;
@@ -70,6 +76,9 @@ public class SceneLoadManager : MonoBehaviour
         Tween fadeIn = overlayUI?.FadeTo(1f, fadeDuration);
         if (fadeIn != null)
             yield return fadeIn.WaitForCompletion();
+
+        if (bgmFadeOut != null && bgmFadeOut.IsActive() && !bgmFadeOut.IsComplete())
+            yield return bgmFadeOut.WaitForCompletion();
 
         AsyncOperation operation = SceneManager.LoadSceneAsync(sceneName);
         if (operation == null)
@@ -87,7 +96,7 @@ public class SceneLoadManager : MonoBehaviour
         while (!operation.isDone)
             yield return null;
 
-        soundManager?.ApplySceneBGM(sceneName);
+        soundManager?.ApplySceneBGM(sceneName, forceBgmFade, bgmFadeDuration);
 
         if (transitionBgm)
             yield return null;

--- a/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/SceneLoadManager.cs
@@ -52,7 +52,12 @@ public class SceneLoadManager : MonoBehaviour
     {
         isLoading = true;
 
-        SoundManager.Instance?.BeginSceneTransitionFadeOut(sceneName);
+        SoundManager soundManager = SoundManager.Instance;
+        bool transitionBgm = soundManager != null && soundManager.ShouldTransitionBGM(sceneName);
+        soundManager?.BeginSceneTransitionFadeOut(sceneName);
+
+        if (transitionBgm)
+            yield return null;
 
         SceneLoadingOverlayBase overlayUI = GetOverlayFor(sceneName);
         if (overlayUI != null)
@@ -82,7 +87,10 @@ public class SceneLoadManager : MonoBehaviour
         while (!operation.isDone)
             yield return null;
 
-        SoundManager.Instance?.ApplySceneBGM(sceneName);
+        soundManager?.ApplySceneBGM(sceneName);
+
+        if (transitionBgm)
+            yield return null;
 
         Tween fadeOut = overlayUI?.FadeTo(0f, fadeDuration);
         if (fadeOut != null)


### PR DESCRIPTION
## 개요

씬 전환 시 BGM이 갑자기 끊기거나 최대 볼륨으로 재생되는 문제를 수정했습니다.
화면 전환과 BGM 페이드 타이밍을 조정하고, 결과 씬에서 메인 씬으로 이동할 때 BGM이 처음부터 자연스럽게 재생되도록 개선했습니다.