### PR TITLE
[Fix] 카드 효과 로직 개선 및 시작 덱 리롤 UI 복구

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -1638,7 +1638,6 @@ RectTransform:
   - {fileID: 702743065}
   - {fileID: 2126212522}
   - {fileID: 1708510079}
-  - {fileID: 2147483602}
   m_Father: {fileID: 579454194}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -8873,7 +8872,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   uiCardPanel: {fileID: 2126212525}
-  rerollButton: {fileID: 2147483605}
+  rerollButton: {fileID: 1865071039}
   commonCardCount: 4
   uncommonCardCount: 2
   uniqueCardCount: 1
@@ -9685,6 +9684,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 602961868}
+  m_CullTransparentMesh: 1
+--- !u!1 &603791384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 603791385}
+  - component: {fileID: 603791387}
+  - component: {fileID: 603791386}
+  m_Layer: 5
+  m_Name: Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &603791385
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603791384}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1865071033}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &603791386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603791384}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da278b4ad962ea49b52e728dab946b4, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
+--- !u!222 &603791387
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603791384}
   m_CullTransparentMesh: 1
 --- !u!1 &618377336
 GameObject:
@@ -14431,6 +14505,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fadeDuration: 0.2
+  bgmFadeDuration: 0.8
   loadingDisplayDelay: 0.2
   basicOverlay: {fileID: 1000000000000000006, guid: c95bb3f83fc44740b72105a3aa01f584, type: 3}
   rainOverlay: {fileID: 4308635123189978070, guid: f70bac25932e1db44b46c7085c4b697b, type: 3}
@@ -25607,7 +25682,7 @@ RectTransform:
   m_LocalScale: {x: 1.0011734, y: 1.0011734, z: 1.0011734}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 2147483602}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -30232,6 +30307,169 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1857583574}
   m_CullTransparentMesh: 1
+--- !u!1 &1865071032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1865071033}
+  - component: {fileID: 1865071037}
+  - component: {fileID: 1865071036}
+  - component: {fileID: 1865071039}
+  - component: {fileID: 1865071038}
+  m_Layer: 5
+  m_Name: RerollBtn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1865071033
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865071032}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0011734, y: 1.0011734, z: 1.0011734}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 2016120986}
+  - {fileID: 603791385}
+  m_Father: {fileID: 2126212522}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 420, y: 170}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1865071036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865071032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 9527febdf2ae1e449ab1eaf04a665ea7, type: 2}
+  m_Color: {r: 0.05490196, g: 0.05490196, b: 0.05490196, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1053917808771471321, guid: 01012e4e38ad1624c9d7452dc99af337, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1865071037
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865071032}
+  m_CullTransparentMesh: 1
+--- !u!114 &1865071038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865071032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77cc6a751d4a4af4abcf2b7df9117de7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1865071039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865071032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1865071036}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 579454196}
+        m_TargetAssemblyTypeName: StartDeckManager, Assembly-CSharp
+        m_MethodName: Reroll
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  clickSound: {fileID: 0}
+  hoverSound: {fileID: 0}
+  disableCanvas: {fileID: 579454195}
+  enableCanvas: {fileID: 0}
+  disablePanel: {fileID: 0}
+  enablePanel: {fileID: 0}
+  buttonType: 0
+  practiceDifficulty: 1
+  uIAnimationObject: {fileID: 0}
+  isStartAnimation: 0
+  isEndAnimation: 0
+  nextSceneName: 
+  practiceSceneName: MainGameScene
+  rewardSceneName: RewardScene
+  resultSceneName: ResultScene
+  mainSceneName: MainScene
 --- !u!1 &1871502567
 GameObject:
   m_ObjectHideFlags: 0
@@ -32912,6 +33150,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2013683063}
   m_CullTransparentMesh: 1
+--- !u!1 &2016120985
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2016120986}
+  - component: {fileID: 2016120988}
+  - component: {fileID: 2016120987}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2016120986
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016120985}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1865071033}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.000080109}
+  m_SizeDelta: {x: 1600, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2016120987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016120985}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uB2E4\uC2DC"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 84
+  m_fontSizeBase: 84
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2016120988
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2016120985}
+  m_CullTransparentMesh: 1
 --- !u!1 &2019662833
 GameObject:
   m_ObjectHideFlags: 0
@@ -34514,6 +34889,7 @@ RectTransform:
   m_Children:
   - {fileID: 910003002}
   - {fileID: 910004002}
+  - {fileID: 1865071033}
   m_Father: {fileID: 154833870}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -35506,3 +35882,4 @@ SceneRoots:
   - {fileID: 1472920803}
   - {fileID: 1994363648}
   - {fileID: 1448069395}
+  - {fileID: 1630974407}

--- a/ChaosChess_v2/Assets/Script/Card/Effector/IEffect.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/IEffect.cs
@@ -18,3 +18,13 @@ public interface ITileEffect : IEffect
     void OnPieceExit(Piece piece);
     bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to);
 }
+
+public interface IPiecePathEffect
+{
+    void OnPieceTraverse(Piece piece, Vector3Int from, Vector3Int to);
+}
+
+public interface IPiecePathBlocker
+{
+    bool CanPieceTraverse(Piece piece, Vector3Int from, Vector3Int to);
+}

--- a/ChaosChess_v2/Assets/Script/Card/SO/WindmillCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/WindmillCard.asset
@@ -25,13 +25,17 @@ MonoBehaviour:
   MaintainTurn: 0
   NeedEffectTileBase: 0
   EffectTileBase: {fileID: 0}
+  UseMultipleEffectTileBases: 0
+  EffectTileBases: []
+  EffectTileAnimationMode: 0
+  EffectTileFrameInterval: 0.2
+  EffectTileAnimationFrames: []
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-  NeedTargetColor: 0
+  NeedTargetColor: 1
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
-  ShowStatusCard: 0
   StatusDisplayType: 2
   NeedAdditionalDescription: 0
   DescriptionType: 0

--- a/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
@@ -52,59 +52,7 @@ public class ATMineEffector : TileEffector, IPiecePathEffect
     public void OnPieceTraverse(Piece piece, Vector3Int from, Vector3Int to)
     {
         if ((TargetPieceTypes & piece.Type) == 0) return;
-
-        int dx = to.x - from.x;
-        int dy = to.y - from.y;
-
-        int adx = Mathf.Abs(dx);
-        int ady = Mathf.Abs(dy);
-
-        Vector3Int dir;
-
-        if (dx == 0 || dy == 0 || adx == ady)
-        {
-            dir = new Vector3Int(
-                Mathf.Clamp(dx, -1, 1),
-                Mathf.Clamp(dy, -1, 1),
-                0
-            );
-        }
-        else if (adx != ady && dx != 0 && dy != 0)
-        {
-            if (adx > ady)
-            {
-                dir = new Vector3Int(
-                    dx / adx * 2,
-                    dy / ady * 1,
-                    0
-                );
-            }
-            else
-            {
-                dir = new Vector3Int(
-                    dx / adx * 1,
-                    dy / ady * 2,
-                    0
-                );
-            }
-        }
-        else
-        {
-            return;
-        }
-
-        Vector3Int curPos = from;
-
-        while (curPos != to)
-        {
-            curPos += dir;
-
-            if (curPos == tilePos)
-            {
-                Explode();
-                return;
-            }
-        }
+        Explode();
     }
 
     private void Explode()

--- a/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ATMineCard.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -26,48 +25,33 @@ public class ATMineCard : CardData, ITileCard
     {
         Vector3Int pos = args.TargetPos[0];
 
-        ATMineEffector effect = CreateGlobalEffector<ATMineEffector>();
-        effect.MinePos = pos;
-
-        PieceType targetPiecesType = (
-            PieceType.Rook | PieceType.Queen | PieceType.King | // 일반 기물
-            PieceType.Amazon | PieceType.Chancellor | PieceType.KnightRider // 커스텀 기물
-        );
-
-        effect.DataSO = DataSO;
-        effect.Init(targetPiecesType);
+        ATMineEffector effect = CreateTileEffector<ATMineEffector>(pos);
         effect.Apply();
     }
 }
 
-public class ATMineEffector : GlobalEffector
+public class ATMineEffector : TileEffector, IPiecePathEffect
 {
-    public CardDataSO DataSO;
+    private const PieceType TargetPieceTypes =
+        PieceType.Rook | PieceType.Queen | PieceType.King |
+        PieceType.Amazon | PieceType.Chancellor | PieceType.KnightRider;
 
-    public Vector3Int MinePos;
     protected override void OnApply()
     {
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(MinePos, DataSO, 0, RemainingTurns);
-
-        BoardManager.Instance.RegisterGlobalEffector(this);
+        ShowTileEffect();
+        BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        if (DataSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(MinePos);
-
-        BoardManager.Instance.UnregisterGlobalEffector(this);
+        ClearTileEffect();
+        BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
     }
 
-    public override void OnPieceAct(Piece piece, Vector3Int dest)
+    public void OnPieceTraverse(Piece piece, Vector3Int from, Vector3Int to)
     {
-        if (!IsWatching(piece)) return;
-
-        Vector3Int from = piece.PrevPos;
-        Vector3Int to = dest;
+        if ((TargetPieceTypes & piece.Type) == 0) return;
 
         int dx = to.x - from.x;
         int dy = to.y - from.y;
@@ -115,7 +99,7 @@ public class ATMineEffector : GlobalEffector
         {
             curPos += dir;
 
-            if (curPos == MinePos)
+            if (curPos == tilePos)
             {
                 Explode();
                 return;
@@ -130,7 +114,7 @@ public class ATMineEffector : GlobalEffector
         {
             for (int y = -1; y <= 1; y++)
             {
-                Vector3Int checkPos = MinePos + new Vector3Int(x, y, 0);
+                Vector3Int checkPos = tilePos + new Vector3Int(x, y, 0);
 
                 Piece target = BoardManager.Instance.GetPiece(checkPos);
                 if (target == null) continue;
@@ -143,10 +127,5 @@ public class ATMineEffector : GlobalEffector
             BoardManager.Instance.RefreshMoves();
 
         Revert();
-    }
-
-    protected override IEnumerable<Vector3Int> GetVisualPositions()
-    {
-        yield return MinePos;
     }
 }

--- a/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/CobwebCard.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System.Collections.Generic;
 
 /// <summary>
 /// 거미줄 - 타일전용
@@ -26,43 +25,35 @@ public class CobwebCard : CardData, ITileCard
     {
         Vector3Int pos = args.TargetPos[0];
 
-        CobwebEffector effect = CreateGlobalEffector<CobwebEffector>();
-        effect.InitCobweb(pos, DataSO);
+        CobwebEffector effect = CreateTileEffector<CobwebEffector>(pos);
+        effect.SetUntilTriggered();
         effect.Apply();
     }
 }
 
-public class CobwebEffector : GlobalEffector
+public class CobwebEffector : TileEffector, IPiecePathBlocker
 {
     private bool isTriggered = false;
 
-    public Vector3Int TilePos;
-
-    public void InitCobweb(Vector3Int tilePos, CardDataSO dataSO)
+    public void SetUntilTriggered()
     {
-        TilePos = tilePos;
-        CardSO = dataSO;
         SetDuration(-1);
     }
 
     protected override void OnApply()
     {
-        if (CardSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.SetTileEffect(TilePos, CardSO, 0, RemainingTurns);
-
-        BoardManager.Instance.RegisterGlobalEffector(this);
+        ShowTileEffect();
+        BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
-        if (CardSO.NeedEffectTileBase)
-            BoardManager.Instance.TileEffectDrawer.ClearTileEffect(TilePos);
-
-        BoardManager.Instance.UnregisterGlobalEffector(this);
+        ClearTileEffect();
+        BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
     }
 
-    public override bool CanPieceAct(Piece piece, Vector3Int from, Vector3Int to)
+    public bool CanPieceTraverse(Piece piece, Vector3Int from, Vector3Int to)
     {
         if (isTriggered) return true;
         if (piece is King) return true;
@@ -73,13 +64,13 @@ public class CobwebEffector : GlobalEffector
         while (cur != to)
         {
             cur += dir;
-            if (cur == TilePos)
+            if (cur == tilePos)
             {
                 if (PieceEffector.HasActiveMovementOverride(piece))
                     return true;
 
                 isTriggered = true;
-                BoardManager.Instance.ForceTeleport(piece, TilePos, '\0', false);
+                BoardManager.Instance.ForceTeleport(piece, tilePos, '\0', false);
                 ApplyStuckEffect(piece);
                 BoardManager.Instance.RefreshMoves();
                 Revert();
@@ -142,11 +133,6 @@ public class CobwebEffector : GlobalEffector
         pieceEffect.CardSO = null;
         pieceEffect.Init(piece, CardSO.LimitTurn);
         pieceEffect.Apply();
-    }
-
-    protected override IEnumerable<Vector3Int> GetVisualPositions()
-    {
-        yield return TilePos;
     }
 }
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
@@ -15,10 +15,8 @@ public class PositionSwapCard : CardData, ICard
 
         string flipped = FlipFEN(fen);
 
-        bm.DestroyPieces(bm.GetAllPieces(), false);
-        bm.LoadFEN(flipped);
+        bm.ReplacePositionFromFen(flipped);
         bm.ClearAllTileEffectors();
-        bm.RefreshMoves();
 
         GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/PositionSwapCard.cs
@@ -15,8 +15,8 @@ public class PositionSwapCard : CardData, ICard
 
         string flipped = FlipFEN(fen);
 
-        bm.ReplacePositionFromFen(flipped);
         bm.ClearAllTileEffectors();
+        bm.ReplacePositionFromFen(flipped);
 
         GameManager.Instance.NextTurn(() => GameManager.Instance.RequestAIMove());
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/TimeReversalCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/TimeReversalCard.cs
@@ -28,10 +28,7 @@ public class TimeReversalEffecter : GlobalEffector
     {
         string NewFEN = BoardManager.Instance.GetFEN();
 
-        BoardManager.Instance.DestroyPieces(BoardManager.Instance.GetAllPieces(), false);
-        BoardManager.Instance.LoadFEN(DefaultFEN);
-
-        BoardManager.Instance.RefreshMoves();
+        BoardManager.Instance.ReplacePositionFromFen(DefaultFEN);
 
         GameManager.Instance.RequestTimeReversal(
             () =>
@@ -41,11 +38,7 @@ public class TimeReversalEffecter : GlobalEffector
             () =>
             {
                 Destroy(gameObject);
-                BoardManager.Instance.DestroyPieces(BoardManager.Instance.GetAllPieces());
-                BoardManager.Instance.LoadFEN(NewFEN);
-
-                BoardManager.Instance.RefreshMoves();
-
+                BoardManager.Instance.ReplacePositionFromFen(NewFEN);
             }
         );
     }

--- a/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/WindmillCard.cs
@@ -10,7 +10,10 @@ public class WindmillCard : CardData, ICard
     public void Execute(CardEffectArgs args = null)
     {
         var effector = CreateGlobalEffector<WindmillEffector>();
-        effector.Init(DataSO.PieceType, ApplyType.All, DataSO.PieceLimitTurn);
+        ApplyType casterColor = GameManager.Instance.turnColor == PieceColor.White
+            ? ApplyType.White
+            : ApplyType.Black;
+        effector.Init(DataSO.PieceType, casterColor, DataSO.PieceLimitTurn);
         effector.Apply();
 
     }
@@ -23,6 +26,9 @@ public class WindmillEffector : GlobalEffector
     {
         foreach (Piece piece in BoardManager.Instance.GetAllPieces())
         {
+            if (!IsWatching(piece))
+                continue;
+
             if (PieceEffector.HasActiveMovementOverride(piece))
                 continue;
 

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -227,6 +227,14 @@ public class BoardManager : MonoBehaviour
         CheckKingExistence();
     }
 
+    /// <summary>중간 보드 상태를 평가하지 않고 현재 기물 배치를 FEN 상태로 교체합니다.</summary>
+    public void ReplacePositionFromFen(string fen)
+    {
+        DestroyPieces(GetAllPieces(), false);
+        LoadFEN(fen);
+        RefreshMoves();
+    }
+
     /// <summary> 모든 기물들이 이동 가능한 위치를 업데이트 합니다 </summary>
     public void UpdatePiecesCanMovePos(string[] moves)
     {

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -707,7 +707,10 @@ public class BoardManager : MonoBehaviour
                 continue;
 
             if (!effector.CanPieceAct(piece, from, to))
+            {
+                Debug.Log($"이동 차단: {effector.GetType().Name}");
                 return false;
+            }
         }
 
         foreach (TileEffector effector in GetAllTileEffectors())
@@ -717,7 +720,10 @@ public class BoardManager : MonoBehaviour
 
             if (effector is IPiecePathBlocker pathBlocker
                 && !pathBlocker.CanPieceTraverse(piece, from, to))
+            {
+                Debug.Log($"이동 경로 차단: {effector.GetType().Name}");
                 return false;
+            }
         }
 
         if (!tileEffectors.TryGetValue(to, out var list)) return true;
@@ -728,7 +734,10 @@ public class BoardManager : MonoBehaviour
                 continue;
 
             if (!effector.CanPieceEnter(piece, from, to))
+            {
+                Debug.Log($"타일 진입 차단: {effector.GetType().Name}");
                 return false;
+            }
         }
 
         return true;

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -713,16 +713,24 @@ public class BoardManager : MonoBehaviour
             }
         }
 
-        foreach (TileEffector effector in GetAllTileEffectors())
+        Vector3Int pathStep = GetPathStep(from, to);
+        for (Vector3Int pos = from + pathStep; pos != to + pathStep; pos += pathStep)
         {
-            if (effector == null || effector.IsSuspended)
+            if (!tileEffectors.TryGetValue(pos, out var pathEffectors))
                 continue;
 
-            if (effector is IPiecePathBlocker pathBlocker
-                && !pathBlocker.CanPieceTraverse(piece, from, to))
+            for (int i = pathEffectors.Count - 1; i >= 0; i--)
             {
-                Debug.Log($"이동 경로 차단: {effector.GetType().Name}");
-                return false;
+                TileEffector effector = pathEffectors[i];
+                if (effector == null || effector.IsSuspended)
+                    continue;
+
+                if (effector is IPiecePathBlocker pathBlocker
+                    && !pathBlocker.CanPieceTraverse(piece, from, to))
+                {
+                    Debug.Log($"이동 경로 차단: {effector.GetType().Name}");
+                    return false;
+                }
             }
         }
 
@@ -820,14 +828,46 @@ public class BoardManager : MonoBehaviour
 
     private void TriggerTilePathEffects(Piece piece, Vector3Int from, Vector3Int to)
     {
-        foreach (TileEffector effector in GetAllTileEffectors())
+        Vector3Int pathStep = GetPathStep(from, to);
+        for (Vector3Int pos = from + pathStep; pos != to + pathStep; pos += pathStep)
         {
-            if (effector == null || effector.IsSuspended)
+            if (!tileEffectors.TryGetValue(pos, out var pathEffectors))
                 continue;
 
-            if (effector is IPiecePathEffect pathEffect)
-                pathEffect.OnPieceTraverse(piece, from, to);
+            for (int i = pathEffectors.Count - 1; i >= 0; i--)
+            {
+                TileEffector effector = pathEffectors[i];
+                if (effector == null || effector.IsSuspended)
+                    continue;
+
+                if (effector is IPiecePathEffect pathEffect)
+                    pathEffect.OnPieceTraverse(piece, from, to);
+            }
         }
+    }
+
+    private static Vector3Int GetPathStep(Vector3Int from, Vector3Int to)
+    {
+        int dx = to.x - from.x;
+        int dy = to.y - from.y;
+        int divisor = GreatestCommonDivisor(Mathf.Abs(dx), Mathf.Abs(dy));
+
+        if (divisor == 0)
+            return Vector3Int.zero;
+
+        return new Vector3Int(dx / divisor, dy / divisor, 0);
+    }
+
+    private static int GreatestCommonDivisor(int a, int b)
+    {
+        while (b != 0)
+        {
+            int remainder = a % b;
+            a = b;
+            b = remainder;
+        }
+
+        return a;
     }
 
     private void TriggerTileEnter(Vector3Int pos, Piece piece)

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -441,6 +441,7 @@ public class BoardManager : MonoBehaviour
         }
 
         TriggerGlobalEffectors(piece, target, isCapture);
+        TriggerTilePathEffects(piece, from, target);
         TriggerTileEnter(target, piece);
 
         foreach (var eff in piece.GetComponents<IPieceEffect>())
@@ -709,6 +710,16 @@ public class BoardManager : MonoBehaviour
                 return false;
         }
 
+        foreach (TileEffector effector in GetAllTileEffectors())
+        {
+            if (effector == null || effector.IsSuspended)
+                continue;
+
+            if (effector is IPiecePathBlocker pathBlocker
+                && !pathBlocker.CanPieceTraverse(piece, from, to))
+                return false;
+        }
+
         if (!tileEffectors.TryGetValue(to, out var list)) return true;
         foreach (var effector in list)
         {
@@ -796,6 +807,18 @@ public class BoardManager : MonoBehaviour
             }
         }
         return new List<TileEffector>(result);
+    }
+
+    private void TriggerTilePathEffects(Piece piece, Vector3Int from, Vector3Int to)
+    {
+        foreach (TileEffector effector in GetAllTileEffectors())
+        {
+            if (effector == null || effector.IsSuspended)
+                continue;
+
+            if (effector is IPiecePathEffect pathEffect)
+                pathEffect.OnPieceTraverse(piece, from, to);
+        }
     }
 
     private void TriggerTileEnter(Vector3Int pos, Piece piece)


### PR DESCRIPTION
## 개요

카드 효과 처리 과정에서 발생하던 보드 상태 판정과 타일 경로 효과 문제를 수정하고, 시작 덱 리롤 UI를 복구했습니다.

## 변경 사항

### FEN 기반 보드 변환 로직 개선

- 보드 교체 과정을 `ReplacePositionFromFen()`으로 통합했습니다.
- 기존 기물을 제거하는 중간 상태에서는 보드 갱신과 결과 판정을 실행하지 않습니다.
- FEN 로드가 완료된 최종 상태에서 이동 가능 수를 한 번만 갱신합니다.
- 이를 통해 시간역행 취소 시 빈 보드가 무승부로 판정되는 문제를 해결했습니다.
- 동일한 보드 변환 로직을 사용하는 위치 교환 카드에도 적용했습니다.

### 타일 경로 효과 처리 개선

- 이동 경로에 반응하는 효과를 위한 `IPiecePathEffect`를 추가했습니다.
- 이동 경로를 차단하는 효과를 위한 `IPiecePathBlocker`를 추가했습니다.
- 경로 효과를 전역 효과가 아닌 타일 효과 레지스트리에서 관리하도록 변경했습니다.
- 일시 정지된 효과는 경로 판정과 실행에서 제외됩니다.
- 이를 통해 대전차지뢰가 설치된 칸에 다른 타일 효과가 중첩되는 문제를 해결했습니다.
- 대전차지뢰의 경로 감지와 폭발 동작, 거미줄의 경로 차단 동작은 기존과 동일하게 유지했습니다.

### 카드 효과 대상 판정 개선

- 카드 사용자의 색상을 기준으로 효과 대상을 필터링하도록 변경했습니다.
- 효과 적용 시 감시 조건과 일치하는 기물만 행마 변경 대상으로 처리합니다.
- 이를 통해 풍차 효과가 상대 기물에도 적용되던 문제와 그로 인한 이동 및 포획 오류를 해결했습니다.
- 이동이 차단되면 차단 단계와 관련 이펙터를 확인할 수 있는 간단한 로그를 추가했습니다.

### 시작 덱 리롤 UI 복구

- 시작 덱 선택 화면에 리롤 버튼을 다시 배치했습니다.
- 버튼 클릭 이벤트를 기존 `StartDeckManager.Reroll()` 로직과 연결했습니다.
- 카드 배치 애니메이션이 완료된 후 버튼이 활성화되도록 기존 흐름을 유지했습니다.

Closes #218
Closes #224