### PR TITLE
[Fix] 버프 보상 선택 로직 개선 및 신규 버프 추가

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -22359,6 +22359,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 021b1f2fcd5848d8b44dca0f54de185b, type: 2}
   - {fileID: 11400000, guid: 3c8755b887ac4bae978717ffa52f9fc5, type: 2}
   - {fileID: 11400000, guid: 7cdb9f47f0a94a8e92d35dc67d731e5e, type: 2}
+  - {fileID: 11400000, guid: b277b67410654f8bb8e96e545753bd01, type: 2}
+  - {fileID: 11400000, guid: d38bc77df2304c6e965cfc6f771f8947, type: 2}
 --- !u!1 &1462519225
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/RewardScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/RewardScene.unity
@@ -327,6 +327,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7cdb9f47f0a94a8e92d35dc67d731e5e, type: 2}
   - {fileID: 11400000, guid: e6267b0aa2ef4d209690f6c66fd57d39, type: 2}
   - {fileID: 11400000, guid: 021b1f2fcd5848d8b44dca0f54de185b, type: 2}
+  - {fileID: 11400000, guid: b277b67410654f8bb8e96e545753bd01, type: 2}
+  - {fileID: 11400000, guid: d38bc77df2304c6e965cfc6f771f8947, type: 2}
   buffPanel: {fileID: 1948879695}
   debuffPanel: {fileID: 761295392}
 --- !u!1 &125163302

--- a/ChaosChess_v2/Assets/Scenes/RewardScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/RewardScene.unity
@@ -4173,7 +4173,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uC544\uAD70 \uB9C8\uC774\uB108 \uAE30\uBB3C 3\uAC1C \uBCBD\uC73C\uB85C
+  m_text: "\uC801\uAD70 \uB9C8\uC774\uB108 \uAE30\uBB3C 3\uAC1C \uBCBD\uC73C\uB85C
     \uBCC0\uD658"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/PawnReinforcementBuff.cs
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/PawnReinforcementBuff.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "BuffSystem/Definitions/PawnReinforcement")]
 public class PawnReinforcementBuff : BuffSO
 {
+    private static readonly int[] CenterFirstFiles = { 3, 4, 2, 5, 1, 6, 0, 7 };
+
     protected override void OnApply(Player player, BuffSide side, int magnitude)
     {
         if (BoardManager.Instance == null || magnitude <= 0) return;
@@ -27,11 +29,7 @@ public class PawnReinforcementBuff : BuffSO
         int spawnCount = Mathf.Min(count, candidates.Count);
         for (int i = 0; i < spawnCount; i++)
         {
-            int randomIndex = Random.Range(0, candidates.Count);
-            Vector3Int pos = candidates[randomIndex];
-            candidates.RemoveAt(randomIndex);
-
-            board.ChangePiece(pos, color, 'p');
+            board.ChangePiece(candidates[i], color, 'p');
         }
     }
 
@@ -62,7 +60,7 @@ public class PawnReinforcementBuff : BuffSO
     private static void TryCollectRankEmpty(int y, List<Vector3Int> result)
     {
         BoardManager board = BoardManager.Instance;
-        for (int x = 0; x < 8; x++)
+        foreach (int x in CenterFirstFiles)
         {
             Vector3Int pos = new Vector3Int(x, y, 0);
             if (board.IsEmpty(pos))

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/RandomPieceRemovalBuff.cs
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/RandomPieceRemovalBuff.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "BuffSystem/Definitions/RandomPieceRemoval")]
+public class RandomPieceRemovalBuff : BuffSO
+{
+    protected override void OnApply(Player player, BuffSide side, int magnitude)
+    {
+        if (BoardManager.Instance == null || magnitude <= 0) return;
+
+        PieceColor targetColor = side == BuffSide.Buff ? PieceColor.Black : PieceColor.White;
+        List<Piece> candidates = GetRemovablePieces(targetColor);
+        if (candidates.Count == 0) return;
+
+        int removeCount = Mathf.Min(magnitude, candidates.Count);
+        for (int i = 0; i < removeCount; i++)
+        {
+            int randomIndex = Random.Range(0, candidates.Count);
+            Piece target = candidates[randomIndex];
+            candidates.RemoveAt(randomIndex);
+
+            BoardManager.Instance.DestroyPiece(target, i == removeCount - 1);
+        }
+    }
+
+    protected override void OnRemove(Player player, BuffSide side, int magnitude)
+    {
+        // 제거 효과는 비가역으로 유지
+    }
+
+    private static List<Piece> GetRemovablePieces(PieceColor color)
+    {
+        return BoardManager.Instance.GetAllPieces().FindAll(piece =>
+            piece != null &&
+            piece.Color == color &&
+            piece.Type != PieceType.King &&
+            piece.Type != PieceType.Queen &&
+            piece.Type != PieceType.Wall);
+    }
+}

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/RandomPieceRemovalBuff.cs.meta
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/RandomPieceRemovalBuff.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c10839c968e849feb5da65c92dd7ddbb

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs
@@ -10,7 +10,8 @@ public class RookToChancellorBuff : BuffSO
 
         PieceColor targetColor = side == BuffSide.Buff ? PieceColor.White : PieceColor.Black;
         List<Rook> rooks = BoardManager.Instance.GetPiece<Rook>(targetColor);
-        if (rooks == null || rooks.Count == 0) return;
+        rooks.RemoveAll(rook => rook == null);
+        if (rooks.Count == 0) return;
 
         int convertCount = Mathf.Min(magnitude, rooks.Count);
         for (int i = 0; i < convertCount; i++)

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "BuffSystem/Definitions/RookToChancellor")]
+public class RookToChancellorBuff : BuffSO
+{
+    protected override void OnApply(Player player, BuffSide side, int magnitude)
+    {
+        if (BoardManager.Instance == null || magnitude <= 0) return;
+
+        PieceColor targetColor = side == BuffSide.Buff ? PieceColor.White : PieceColor.Black;
+        List<Rook> rooks = BoardManager.Instance.GetPiece<Rook>(targetColor);
+        if (rooks == null || rooks.Count == 0) return;
+
+        int convertCount = Mathf.Min(magnitude, rooks.Count);
+        for (int i = 0; i < convertCount; i++)
+        {
+            int randomIndex = Random.Range(0, rooks.Count);
+            Rook target = rooks[randomIndex];
+            rooks.RemoveAt(randomIndex);
+
+            BoardManager.Instance.ChangePiece(target.Pos, targetColor, 'y');
+        }
+    }
+
+    protected override void OnRemove(Player player, BuffSide side, int magnitude)
+    {
+        // 기물 변환은 비가역 효과로 유지
+    }
+}

--- a/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs.meta
+++ b/ChaosChess_v2/Assets/Script/Buff/Buffs/RookToChancellorBuff.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6ccbd9cd5ae4b17a87b520897f4d921

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/CardIntervalBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/CardIntervalBuff.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 181601e4be9d4fe189604eb7d42a9458, type: 3}
   m_Name: CardIntervalBuff
   m_EditorClassIdentifier: 
-  buffDescription: "\uCE74\uB4DC \uD68D\uB4DD \uC8FC\uAE30 {value} \uAC10\uC18C"
+  buffDescription: "\uCE74\uB4DC \uD68D\uB4DD \uC8FC\uAE30 {value}\uD134 \uAC10\uC18C"
   debuffDescription: "\uCE74\uB4DC \uD68D\uB4DD \uC8FC\uAE30 {value}\uD134 \uC99D\uAC00"
   hasBuff: 1
   buffWeight: 300

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/PawnReinforcementBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/PawnReinforcementBuff.asset
@@ -18,10 +18,10 @@ MonoBehaviour:
   buffWeight: 50
   buffValue: 1
   useRandomBuffValue: 1
-  buffRange: {x: 1, y: 5}
+  buffRange: {x: 1, y: 4}
   useTensOnly: 0
   hasDebuff: 1
-  debuffWeight: 50
+  debuffWeight: 30
   debuffValue: 1
   useRandomDebuffValue: 1
-  debuffRange: {x: 1, y: 5}
+  debuffRange: {x: 1, y: 4}

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomMinorToWallBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomMinorToWallBuff.asset
@@ -17,13 +17,13 @@ MonoBehaviour:
   debuffDescription: "\uC544\uAD70 \uB9C8\uC774\uB108 \uAE30\uBB3C {value}\uAC1C\uB97C
     \uBCBD\uC73C\uB85C \uBCC0\uD658"
   hasBuff: 1
-  buffWeight: 75
+  buffWeight: 25
   buffValue: 1
   useRandomBuffValue: 1
   buffRange: {x: 1, y: 2}
   useTensOnly: 0
   hasDebuff: 1
-  debuffWeight: 75
+  debuffWeight: 25
   debuffValue: 1
   useRandomDebuffValue: 1
   debuffRange: {x: 1, y: 2}

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPawnToWallBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPawnToWallBuff.asset
@@ -16,13 +16,13 @@ MonoBehaviour:
   debuffDescription: "\uC544\uAD70 \uD3F0 {value}\uAC1C\uB97C \uBCBD\uC73C\uB85C
     \uBCC0\uD658"
   hasBuff: 1
-  buffWeight: 125
+  buffWeight: 25
   buffValue: 1
   useRandomBuffValue: 1
-  buffRange: {x: 1, y: 3}
+  buffRange: {x: 1, y: 2}
   useTensOnly: 0
   hasDebuff: 1
-  debuffWeight: 125
+  debuffWeight: 25
   debuffValue: 1
   useRandomDebuffValue: 1
-  debuffRange: {x: 1, y: 3}
+  debuffRange: {x: 1, y: 2}

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPieceRemovalBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPieceRemovalBuff.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c10839c968e849feb5da65c92dd7ddbb, type: 3}
+  m_Name: RandomPieceRemovalBuff
+  m_EditorClassIdentifier: 
+  buffDescription: "\uC801\uAD70 \uD0B9\uACFC \uD038\uC744 \uC81C\uC678\uD55C \uAE30\uBB3C
+    {value}\uAC1C \uC81C\uAC70"
+  debuffDescription: "\uC544\uAD70 \uD0B9\uACFC \uD038\uC744 \uC81C\uC678\uD55C \uAE30\uBB3C
+    {value}\uAC1C \uC81C\uAC70"
+  hasBuff: 1
+  buffWeight: 20
+  buffValue: 1
+  useRandomBuffValue: 0
+  buffRange: {x: 1, y: 1}
+  useTensOnly: 0
+  hasDebuff: 1
+  debuffWeight: 20
+  debuffValue: 1
+  useRandomDebuffValue: 0
+  debuffRange: {x: 1, y: 1}

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPieceRemovalBuff.asset.meta
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RandomPieceRemovalBuff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d38bc77df2304c6e965cfc6f771f8947
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RookToChancellorBuff.asset
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RookToChancellorBuff.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6ccbd9cd5ae4b17a87b520897f4d921, type: 3}
+  m_Name: RookToChancellorBuff
+  m_EditorClassIdentifier: 
+  buffDescription: "\uC544\uAD70 \uB8E9 {value}\uAC1C\uB97C \uCCB8\uC2AC\uB7EC\uB85C
+    \uBCC0\uD658"
+  debuffDescription: "\uC801\uAD70 \uB8E9 {value}\uAC1C\uB97C \uCCB8\uC2AC\uB7EC\uB85C
+    \uBCC0\uD658"
+  hasBuff: 1
+  buffWeight: 20
+  buffValue: 1
+  useRandomBuffValue: 0
+  buffRange: {x: 1, y: 1}
+  useTensOnly: 0
+  hasDebuff: 1
+  debuffWeight: 20
+  debuffValue: 1
+  useRandomDebuffValue: 0
+  debuffRange: {x: 1, y: 1}

--- a/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RookToChancellorBuff.asset.meta
+++ b/ChaosChess_v2/Assets/Script/Buff/SO/Buffs/RookToChancellorBuff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b277b67410654f8bb8e96e545753bd01
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ChaosChess_v2/Assets/Script/UI/NotIngame/BuffRewardManager.cs
+++ b/ChaosChess_v2/Assets/Script/UI/NotIngame/BuffRewardManager.cs
@@ -13,36 +13,135 @@ public class BuffRewardManager : MonoBehaviour
 
     void Start()
     {
-        RollReward();
+        RollDistinctPair(out _selectedBuff, out _selectedDebuff);
 
         buffPanel.Init(_selectedBuff, BuffSide.Buff);
         debuffPanel.Init(_selectedDebuff, BuffSide.Debuff);
     }
 
-    private void RollReward()
+    /// <summary>
+    /// 가능한 경우 같은 BuffSO가 동시에 나오지 않도록 버프/디버프 한 쌍을 가중치 기반으로 선택합니다.
+    /// </summary>
+    private void RollDistinctPair(out BuffSO selectedBuff, out BuffSO selectedDebuff)
     {
-        _selectedBuff = RollBySide(BuffSide.Buff);
-        _selectedDebuff = RollBySide(BuffSide.Debuff);
-    }
+        selectedBuff = null;
+        selectedDebuff = null;
 
-    private BuffSO RollBySide(BuffSide side)
-    {
-        List<BuffSO> candidates = buffPool.FindAll(x => x != null && x.CanUse(side));
-        if (candidates.Count == 0) return null;
+        // 1. 양쪽에서 실제로 등장 가능한 후보를 모읍니다.
+        List<BuffSO> buffCandidates = buffPool.FindAll(x => x != null && x.CanUse(BuffSide.Buff));
+        List<BuffSO> debuffCandidates = buffPool.FindAll(x => x != null && x.CanUse(BuffSide.Debuff));
+        if (buffCandidates.Count == 0 || debuffCandidates.Count == 0) return;
 
-        int totalWeight = 0;
-        foreach (BuffSO candidate in candidates)
+        // 후보가 같은 1개뿐이면 같은 종류 동시 등장을 예외적으로 허용합니다.
+        if (buffCandidates.Count == 1 && debuffCandidates.Count == 1)
         {
-            totalWeight += candidate.GetWeight(side);
+            selectedBuff = buffCandidates[0];
+            selectedDebuff = debuffCandidates[0];
+            return;
         }
 
-        if (totalWeight <= 0) return candidates[Random.Range(0, candidates.Count)];
+        // 2. 버프 후보별 쌍 가중치 계산에 사용할 디버프 전체 가중치를 구합니다.
+        int totalDebuffWeight = 0;
+        foreach (BuffSO debuffCandidate in debuffCandidates)
+        {
+            totalDebuffWeight += debuffCandidate.GetWeight(BuffSide.Debuff);
+        }
 
-        int roll = Random.Range(0, totalWeight);
+        if (totalDebuffWeight <= 0)
+        {
+            PickFirstDistinctPair(buffCandidates, debuffCandidates, out selectedBuff, out selectedDebuff);
+            return;
+        }
+
+        // 3. 같은 BuffSO를 제외했을 때 가능한 모든 쌍의 총 가중치를 구합니다.
+        int totalPairWeight = 0;
+        foreach (BuffSO buffCandidate in buffCandidates)
+        {
+            int buffWeight = buffCandidate.GetWeight(BuffSide.Buff);
+            int blockedDebuffWeight = buffCandidate.CanUse(BuffSide.Debuff)
+                ? buffCandidate.GetWeight(BuffSide.Debuff)
+                : 0;
+
+            // 버프 후보별로 함께 나올 수 있는 디버프 총 가중치를 반영합니다.
+            totalPairWeight += buffWeight * Mathf.Max(0, totalDebuffWeight - blockedDebuffWeight);
+        }
+
+        if (totalPairWeight <= 0)
+        {
+            PickFirstDistinctPair(buffCandidates, debuffCandidates, out selectedBuff, out selectedDebuff);
+            return;
+        }
+
+        // 4. 총 쌍 가중치에서 버프를 먼저 선택합니다.
+        int roll = Random.Range(0, totalPairWeight);
+        int accumulated = 0;
+
+        foreach (BuffSO buffCandidate in buffCandidates)
+        {
+            int buffWeight = buffCandidate.GetWeight(BuffSide.Buff);
+            int blockedDebuffWeight = buffCandidate.CanUse(BuffSide.Debuff)
+                ? buffCandidate.GetWeight(BuffSide.Debuff)
+                : 0;
+            int candidatePairWeight = buffWeight * Mathf.Max(0, totalDebuffWeight - blockedDebuffWeight);
+
+            accumulated += candidatePairWeight;
+            if (roll < accumulated)
+            {
+                selectedBuff = buffCandidate;
+                // 5. 선택된 버프와 같은 BuffSO만 제외하고 디버프를 가중치 기반으로 선택합니다.
+                selectedDebuff = RollFromCandidatesExcluding(
+                    debuffCandidates,
+                    BuffSide.Debuff,
+                    selectedBuff,
+                    totalDebuffWeight);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 가중치 기반 선택이 불가능할 때 첫 번째 유효 쌍을 고정 선택합니다.
+    /// </summary>
+    private void PickFirstDistinctPair(
+        List<BuffSO> buffCandidates,
+        List<BuffSO> debuffCandidates,
+        out BuffSO selectedBuff,
+        out BuffSO selectedDebuff)
+    {
+        foreach (BuffSO buffCandidate in buffCandidates)
+        {
+            foreach (BuffSO debuffCandidate in debuffCandidates)
+            {
+                if (buffCandidate == debuffCandidate) continue;
+
+                selectedBuff = buffCandidate;
+                selectedDebuff = debuffCandidate;
+                return;
+            }
+        }
+
+        selectedBuff = buffCandidates[0];
+        selectedDebuff = debuffCandidates[0];
+    }
+
+    /// <summary>
+    /// 이미 계산된 후보/전체 가중치를 재사용해 특정 BuffSO만 제외하고 하나를 선택합니다.
+    /// </summary>
+    private BuffSO RollFromCandidatesExcluding(List<BuffSO> candidates, BuffSide side, BuffSO excluded, int totalWeight)
+    {
+        // 1. 제외할 후보의 가중치를 전체 가중치에서 빼 실제 선택 가능한 가중치를 구합니다.
+        int excludedWeight = excluded != null && excluded.CanUse(side) ? excluded.GetWeight(side) : 0;
+        int availableWeight = Mathf.Max(0, totalWeight - excludedWeight);
+        if (availableWeight <= 0) return null;
+
+        // 2. 제외 후보를 건너뛰면서 남은 후보 중 하나를 가중치 기반으로 선택합니다.
+        int roll = Random.Range(0, availableWeight);
         int accumulated = 0;
 
         foreach (BuffSO candidate in candidates)
         {
+            if (candidate == excluded) continue;
+
             accumulated += candidate.GetWeight(side);
             if (roll < accumulated)
             {
@@ -50,6 +149,6 @@ public class BuffRewardManager : MonoBehaviour
             }
         }
 
-        return candidates[candidates.Count - 1];
+        return null;
     }
 }


### PR DESCRIPTION
## 개요

버프 보상 선택 방식과 일부 버프 효과를 개선했습니다.

동일한 종류의 버프/디버프가 동시에 등장하지 않도록 선택 로직을 수정했고, 폰 증원 효과는 진영에 가까운 위치와 중앙 우선 배치가 되도록 변경했습니다. 또한 룩을 챈슬러로 변환하는 버프와 무작위 기물 제거 버프를 새로 추가했습니다.

## 변경 사항

### 버프/디버프 중복 선택 방지

동일한 `BuffSO`가 버프와 디버프에 동시에 등장하지 않도록 보상 선택 로직을 수정했습니다.

모든 버프/디버프 조합을 직접 생성하는 대신, 각 버프의 가중치에 함께 등장할 수 있는 디버프의 총가중치를 반영한 뒤 디버프를 선택합니다.

```text
버프 선택 가중치
= 버프 가중치 × (전체 디버프 가중치 - 동일 효과의 디버프 가중치)
```

이 방식을 사용한 이유는 다음과 같습니다.

- 버프를 먼저 단순 추첨할 때 발생하는 확률 편향 방지
- 전체 조합을 생성하는 O(n²) 방식보다 적은 계산량
- 기존 버프 및 디버프 가중치 유지
- 동일 효과의 동시 등장 방지

### 폰 증원 배치 개선

폰 증원 효과의 무작위 배치를 제거했습니다.

- 각 진영에 가까운 행부터 배치
- 같은 행에서는 중앙 칸부터 배치
- 중앙에서 바깥쪽으로 확장

중앙 우선순위는 `3, 4, 2, 5, 1, 6, 0, 7` 순서입니다.

### 신규 버프 추가

#### 룩 → 챈슬러 변환

- 버프: 아군 룩 1개를 챈슬러로 변환
- 디버프: 적군 룩 1개를 챈슬러로 변환
- 낮은 등장 가중치 적용

#### 무작위 기물 제거

- 버프: 적군 기물 1개 제거
- 디버프: 아군 기물 1개 제거
- 킹, 퀸, 벽은 제거 대상에서 제외
- 낮은 등장 가중치 적용

### 기타 수정

- 버프 칸에 저장되어 있던 디버프성 기본 문구 수정
- 신규 버프를 보상 풀과 `BuffRegistry`에 등록
- 관련 메서드 이름과 주석 정리
- 중복 계산을 줄이도록 가중치 계산 결과 재사용