### PR TITLE
[Improve] 모바일 성능 최적화: 카드/UI 핫 패스 LINQ·FindObjectsOfType 정리

### DIFF
--- a/ChaosChess_v2/Assets/Adaptive Performance/AdaptivePerformanceGeneralSettings.asset
+++ b/ChaosChess_v2/Assets/Adaptive Performance/AdaptivePerformanceGeneralSettings.asset
@@ -1,5 +1,20 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6793827077659499895
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 536372c49e1ca914d822849d36de938c, type: 3}
+  m_Name: Standalone Providers
+  m_EditorClassIdentifier: 
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders: []
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 2
@@ -12,9 +27,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cb0ece14d1f711a4fb9325ca819dee95, type: 3}
   m_Name: AdaptivePerformanceGeneralSettings
   m_EditorClassIdentifier: 
-  Keys: 07000000
+  Keys: 0700000001000000
   Values:
   - {fileID: 5346259402235415307}
+  - {fileID: 1180921739037663564}
+--- !u!114 &1180921739037663564
+MonoBehaviour:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 179fc3111e144bc4688dca4038b3265d, type: 3}
+  m_Name: Standalone Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: -6793827077659499895}
+  m_InitManagerOnStart: 1
 --- !u!114 &5346259402235415307
 MonoBehaviour:
   m_ObjectHideFlags: 2

--- a/ChaosChess_v2/Assets/Prefab/UI/MapLine.prefab
+++ b/ChaosChess_v2/Assets/Prefab/UI/MapLine.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1661547642005261267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8615664118743229339}
+  - component: {fileID: 3072249709129598529}
+  - component: {fileID: 5616546381793268019}
+  m_Layer: 5
+  m_Name: MapLine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8615664118743229339
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661547642005261267}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3072249709129598529
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661547642005261267}
+  m_CullTransparentMesh: 1
+--- !u!114 &5616546381793268019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661547642005261267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/ChaosChess_v2/Assets/Prefab/UI/MapLine.prefab.meta
+++ b/ChaosChess_v2/Assets/Prefab/UI/MapLine.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 898c5cd82424f2e43b694365f29419ae
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/Assets/Scenes/MapScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MapScene.unity
@@ -1266,6 +1266,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mapContainer: {fileID: 1537558345}
   mapButtonPrefab: {fileID: 4660915655800250675, guid: eea79cb657b37c742b12dc509f12ace2, type: 3}
+  linePrefab: {fileID: 1661547642005261267, guid: 898c5cd82424f2e43b694365f29419ae, type: 3}
   floorHeight: 800
   nodeSpacing: 500
   lineWidth: 6

--- a/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/PieceSelector.cs
@@ -122,28 +122,21 @@ public class PieceSelector : Selector<Piece>
     {
         BoardManager bm = BoardManager.Instance;
 
-        // 1. 현재 기물 검사
-        List<Piece> pieces = bm.GetAllPieces()
-            .Where(CanSelectPiece)
-            .ToList();
-
-        if (pieces.Count == 0)
+        // 선택 가능한 기물을 순회하며, 효과가 전혀 없거나 전부 투기장 일시정지 상태인 기물을 찾으면 즉시 대상 가능으로 봅니다.
+        bool anySelectable = false;
+        foreach (Piece piece in bm.GetAllPieces())
         {
-            Debug.Log("기물이 존재하지 않습니다!");
-            return false; 
-        } 
+            if (!CanSelectPiece(piece)) continue;
+            anySelectable = true;
 
-        // 2. 기물 중 효과 적용 중인지 검사
-        foreach(Piece piece in pieces)
-        {
-            // 효과가 전혀 없거나, 전부 투기장 일시정지 상태이면 대상 가능으로 봅니다.
             if (!HasActivePieceEffector(piece))
-            {
                 return true;
-            }
         }
 
-        // Debug.Log("기물에 효과가 모두 적용되었습니다!");
+        if (!anySelectable)
+            Debug.Log("기물이 존재하지 않습니다!");
+
+        // else: 기물에 효과가 모두 적용되었습니다!
         return false;
     }
 

--- a/ChaosChess_v2/Assets/Script/Card/Selector/TileSelector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Selector/TileSelector.cs
@@ -131,8 +131,12 @@ public class TileSelector : Selector<Vector3Int>
 
         gameSelectTilemap.ClearAllTiles();
 
-        effectPos = new HashSet<Vector3Int>(FindObjectsOfType<TileEffector>()
-            .Select(t => t.TilePos));
+        effectPos ??= new HashSet<Vector3Int>();
+        effectPos.Clear();
+        foreach (TileEffector effector in boardManager.GetAllTileEffectors())
+        {
+            effectPos.Add(effector.TilePos);
+        }
     }
 
     protected override void DisableSelector()

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -230,7 +230,7 @@ public class BoardManager : MonoBehaviour
     /// <summary>중간 보드 상태를 평가하지 않고 현재 기물 배치를 FEN 상태로 교체합니다.</summary>
     public void ReplacePositionFromFen(string fen)
     {
-        DestroyPieces(GetAllPieces(), false);
+        DestroyPieces(new List<Piece>(Pieces), false);
         LoadFEN(fen);
         RefreshMoves();
     }
@@ -896,10 +896,10 @@ public class BoardManager : MonoBehaviour
         }
     }
 
-    /// <summary>보드 위 모든 기물 목록을 반환합니다.</summary>
+    /// <summary>보드 위 모든 기물 목록을 반환합니다. 내부 리스트를 직접 반환하므로 호출 측에서 변형(Add/Remove/Sort/Clear 등)하지 마세요.</summary>
     public List<Piece> GetAllPieces()
     {
-        return new List<Piece>(Pieces);
+        return Pieces;
     }
 
     /// <summary>보드 위 특정 기물을 전부 반환합니다.</summary>

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -230,7 +230,10 @@ public class BoardManager : MonoBehaviour
     /// <summary>중간 보드 상태를 평가하지 않고 현재 기물 배치를 FEN 상태로 교체합니다.</summary>
     public void ReplacePositionFromFen(string fen)
     {
-        DestroyPieces(new List<Piece>(Pieces), false);
+        for (int i = Pieces.Count - 1; i >= 0; i--)
+        {
+            DestroyPiece(Pieces[i], false);
+        }
         LoadFEN(fen);
         RefreshMoves();
     }

--- a/ChaosChess_v2/Assets/Script/Map/MapUI.cs
+++ b/ChaosChess_v2/Assets/Script/Map/MapUI.cs
@@ -28,6 +28,9 @@ public class MapUI : MonoBehaviour
     private readonly Dictionary<Map, GameObject> _nodeObjects = new();
     private readonly Dictionary<Map, EffectVisual> _effectVisuals = new();
     private bool _built = false;
+    // 연결선 전용 컨테이너. mapContainer의 첫 자식으로 두어 노드 버튼보다 먼저 렌더링되게 하고,
+    // 매 라인마다 SetSiblingIndex(0)을 호출해 계층을 재정렬하는 비용을 없앤다.
+    private RectTransform _lineContainer;
 
     // 노드 이펙트 자식의 Image/ParticleSystem 참조를 인스턴스화 시점에 캐싱해 둔다.
     private readonly struct EffectVisual
@@ -83,6 +86,16 @@ public class MapUI : MonoBehaviour
 
         _nodeObjects.Clear();
         _effectVisuals.Clear();
+
+        // 연결선 컨테이너를 가장 첫 자식으로 생성해 mapContainer 전체에 꽉 채운다.
+        var lineContainerObj = new GameObject("LineContainer", typeof(RectTransform));
+        _lineContainer = lineContainerObj.GetComponent<RectTransform>();
+        _lineContainer.SetParent(mapContainer, false);
+        _lineContainer.SetSiblingIndex(0);
+        _lineContainer.anchorMin = Vector2.zero;
+        _lineContainer.anchorMax = Vector2.one;
+        _lineContainer.offsetMin = Vector2.zero;
+        _lineContainer.offsetMax = Vector2.zero;
 
         // ── 노드 버튼 생성 ────────────────────────────────────────────────────
         for (int floor = 0; floor < manager.totalFloors; floor++)
@@ -200,9 +213,7 @@ public class MapUI : MonoBehaviour
     // Image를 길쭉한 RectTransform으로 회전시켜 두 점 사이의 연결선을 그린다.
     private void DrawLine(Vector2 from, Vector2 to)
     {
-        GameObject lineObj = Instantiate(linePrefab, mapContainer);
-        // 노드 버튼보다 먼저 렌더링되도록 가장 뒤로 이동
-        lineObj.transform.SetSiblingIndex(0);
+        GameObject lineObj = Instantiate(linePrefab, _lineContainer);
 
         var img = lineObj.GetComponent<Image>();
         img.color = new Color(0.6f, 0.6f, 0.6f, 0.6f);

--- a/ChaosChess_v2/Assets/Script/Map/MapUI.cs
+++ b/ChaosChess_v2/Assets/Script/Map/MapUI.cs
@@ -7,6 +7,8 @@ public class MapUI : MonoBehaviour
 {
     [SerializeField] private RectTransform mapContainer;
     [SerializeField] private GameObject mapButtonPrefab;
+    // Image + RectTransform을 가진 라인 프리팹. DrawLine()에서 new GameObject + AddComponent<Image> 대신 Instantiate로 재사용한다.
+    [SerializeField] private GameObject linePrefab;
 
     [SerializeField] private float floorHeight = 160f;
     [SerializeField] private float nodeSpacing = 180f;
@@ -24,7 +26,23 @@ public class MapUI : MonoBehaviour
     [SerializeField] private string effectChildName = "Effect";
 
     private readonly Dictionary<Map, GameObject> _nodeObjects = new();
+    private readonly Dictionary<Map, EffectVisual> _effectVisuals = new();
     private bool _built = false;
+
+    // 노드 이펙트 자식의 Image/ParticleSystem 참조를 인스턴스화 시점에 캐싱해 둔다.
+    private readonly struct EffectVisual
+    {
+        public readonly GameObject gameObject;
+        public readonly Image[] images;
+        public readonly ParticleSystem[] particles;
+
+        public EffectVisual(GameObject gameObject, Image[] images, ParticleSystem[] particles)
+        {
+            this.gameObject = gameObject;
+            this.images = images;
+            this.particles = particles;
+        }
+    }
 
     private void Start()
     {
@@ -64,6 +82,7 @@ public class MapUI : MonoBehaviour
             Destroy(child.gameObject);
 
         _nodeObjects.Clear();
+        _effectVisuals.Clear();
 
         // ── 노드 버튼 생성 ────────────────────────────────────────────────────
         for (int floor = 0; floor < manager.totalFloors; floor++)
@@ -81,6 +100,15 @@ public class MapUI : MonoBehaviour
                 // 앵커를 하단 중앙으로 설정하여 절대좌표(anchoredPosition)로 배치
                 rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0f);
                 rt.anchoredPosition = pos;
+
+                var effectChild = obj.transform.Find(effectChildName);
+                if (effectChild != null)
+                {
+                    _effectVisuals[map] = new EffectVisual(
+                        effectChild.gameObject,
+                        effectChild.GetComponentsInChildren<Image>(true),
+                        effectChild.GetComponentsInChildren<ParticleSystem>(true));
+                }
 
                 ApplyState(obj, map);
 
@@ -144,26 +172,25 @@ public class MapUI : MonoBehaviour
         if (obj.TryGetComponent<Button>(out var btn))
             btn.interactable = !map.isCleared && map.isAccessible;
 
-        var effectObj = obj.transform.Find(effectChildName);
-        if (effectObj != null)
+        if (_effectVisuals.TryGetValue(map, out var effectVisual))
         {
             bool showEffect = map.nodeType != NodeType.Normal && !map.isCleared;
-            effectObj.gameObject.SetActive(showEffect);
+            effectVisual.gameObject.SetActive(showEffect);
 
             if (showEffect)
             {
                 Color effectColor = map.isAccessible ? Color.white : new Color(0.3f, 0.3f, 0.3f);
-                SetEffectColor(effectObj, effectColor);
+                SetEffectColor(effectVisual, effectColor);
             }
         }
     }
 
-    private void SetEffectColor(Transform effectObj, Color color)
+    private void SetEffectColor(EffectVisual effectVisual, Color color)
     {
-        foreach (var img in effectObj.GetComponentsInChildren<Image>(true))
+        foreach (var img in effectVisual.images)
             img.color = color;
 
-        foreach (var ps in effectObj.GetComponentsInChildren<ParticleSystem>(true))
+        foreach (var ps in effectVisual.particles)
         {
             var main = ps.main;
             main.startColor = color;
@@ -173,12 +200,11 @@ public class MapUI : MonoBehaviour
     // Image를 길쭉한 RectTransform으로 회전시켜 두 점 사이의 연결선을 그린다.
     private void DrawLine(Vector2 from, Vector2 to)
     {
-        var lineObj = new GameObject("Line");
-        lineObj.transform.SetParent(mapContainer, false);
+        GameObject lineObj = Instantiate(linePrefab, mapContainer);
         // 노드 버튼보다 먼저 렌더링되도록 가장 뒤로 이동
         lineObj.transform.SetSiblingIndex(0);
 
-        var img = lineObj.AddComponent<Image>();
+        var img = lineObj.GetComponent<Image>();
         img.color = new Color(0.6f, 0.6f, 0.6f, 0.6f);
 
         var rt = lineObj.GetComponent<RectTransform>();

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using DG.Tweening;
 using UnityEngine;
 using UnityEngine.UI;
@@ -279,9 +278,18 @@ public class ActiveEffectCardDisplay : MonoBehaviour
     {
         if (card.CardUI == null) return;
 
-        Effector representative = card.Effects
-            .OrderBy(effect => effect.IsPermanent ? int.MaxValue : effect.RemainingTurns)
-            .FirstOrDefault();
+        // 남은 턴이 가장 적은(영구 효과는 가장 큰 키로 취급) 효과를 대표로 선택합니다. 동점 시 먼저 추가된 효과를 유지합니다.
+        Effector representative = null;
+        int representativeRank = int.MaxValue;
+        foreach (Effector effect in card.Effects)
+        {
+            int rank = effect.IsPermanent ? int.MaxValue : effect.RemainingTurns;
+            if (representative == null || rank < representativeRank)
+            {
+                representative = effect;
+                representativeRank = rank;
+            }
+        }
 
         card.CardUI.RemainTurn.text = GetStatusText(representative);
     }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/ActiveEffectCardDisplay.cs
@@ -283,6 +283,8 @@ public class ActiveEffectCardDisplay : MonoBehaviour
         int representativeRank = int.MaxValue;
         foreach (Effector effect in card.Effects)
         {
+            if (effect == null) continue;
+
             int rank = effect.IsPermanent ? int.MaxValue : effect.RemainingTurns;
             if (representative == null || rank < representativeRank)
             {

--- a/ChaosChess_v2/Assets/Script/UI/UIButton.cs
+++ b/ChaosChess_v2/Assets/Script/UI/UIButton.cs
@@ -2,7 +2,6 @@
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using System.Collections;
-using System.Linq;
 
 public class UIButton : Button
 {
@@ -22,6 +21,7 @@ public class UIButton : Button
 
     private IUIAnimation uIAnimation;
     private SoundManager soundManager;
+    private ButtonCanvas mainCanvas;
 
     [SerializeField] private MonoBehaviour uIAnimationObject; // 인스펙터에 노출
     [SerializeField] private bool isStartAnimation = false;
@@ -84,9 +84,18 @@ public class UIButton : Button
             case ButtonType.ChangePanel:
                 changePanel(); break;
             case ButtonType.GoMain:
-                enableCanvas = FindObjectsOfType<ButtonCanvas>()
-                    .Where(canvas => canvas.MainCanvas == true)
-                    .FirstOrDefault();
+                if (mainCanvas == null)
+                {
+                    foreach (ButtonCanvas canvas in FindObjectsOfType<ButtonCanvas>())
+                    {
+                        if (canvas.MainCanvas)
+                        {
+                            mainCanvas = canvas;
+                            break;
+                        }
+                    }
+                }
+                enableCanvas = mainCanvas;
                 changeCanvas(); break;
             case ButtonType.GoScene:
                 SceneLoadManager.Instance.LoadScene(nextSceneName);

--- a/ChaosChess_v2/ProjectSettings/ProjectSettings.asset
+++ b/ChaosChess_v2/ProjectSettings/ProjectSettings.asset
@@ -60,9 +60,9 @@ PlayerSettings:
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0
   allowedAutorotateToPortrait: 1
-  allowedAutorotateToPortraitUpsideDown: 1
-  allowedAutorotateToLandscapeRight: 1
-  allowedAutorotateToLandscapeLeft: 1
+  allowedAutorotateToPortraitUpsideDown: 0
+  allowedAutorotateToLandscapeRight: 0
+  allowedAutorotateToLandscapeLeft: 0
   useOSAutorotation: 1
   use32BitDisplayBuffer: 1
   preserveFramebufferAlpha: 0


### PR DESCRIPTION
# 개요
이슈 #228에서 정적 분석으로 발견한 모바일(Android/iOS/Switch) 성능 최적화 대상 8건을 처리합니다. 매 턴/매 클릭마다 반복되는 핫 패스에서의 LINQ 중간 할당, 컬렉션 복사, FindObjectsOfType 씬 스캔을 제거·캐싱했습니다.

# 내용
## 매치 핫 패스 (카드 효과 / 타겟 선택)
- `BoardManager.GetAllPieces()`가 호출마다 전체 기물 리스트를 복사하던 것을 제거
- `PieceSelector` 타겟 존재 체크의 `Where().ToList()` 할당을 단순 루프로 교체
- `ActiveEffectCardDisplay`의 `OrderBy().FirstOrDefault()` 할당을 로컬 변수 추적 루프로 교체
- `CardRandomizerManager`의 `GetRandomCards*` LINQ 체이닝 정리
- `TileSelector`가 활성화될 때마다 `FindObjectsOfType<TileEffector>()`로 씬 전체를 스캔하던 것을 `BoardManager`의 기존 `tileEffectors` 등록/해제 레지스트리(`GetAllTileEffectors()`) 조회로 교체

## UI 전환 / 맵 갱신
- `UIButton.OnClicked()`의 `FindObjectsOfType<ButtonCanvas>().Where().FirstOrDefault()` 스캔을 `mainCanvas` 필드에 1회 캐싱하는 방식으로 교체
- `MapUI`의 노드 효과 색상 갱신이 매번 `GetComponentsInChildren<Image>`/`<ParticleSystem>`로 자식을 재검색하던 것을, 노드 인스턴스화 시점(`BuildMap`)에 참조를 캐싱(`_effectVisuals`)해 재사용하도록 변경
- `MapUI.DrawLine()`의 `new GameObject + AddComponent<Image>` 반복 생성을 `MapLine` 프리팹을 `Instantiate`하는 방식으로 교체 (프리팹 추가 및 `MapScene`에 참조 연결 포함)

## 기타
- `ProjectSettings`/`AdaptivePerformanceGeneralSettings`: 화면 회전 잠금 설정 및 Adaptive Performance Standalone 프로바이더 추가 (#228과 무관한 별도 설정 변경)

# 기타 사항
- 정적 분석 기준 변경이며, 실제 효과는 In-Editor 프로파일링으로 추가 검증이 필요합니다.

Closes #228