### PR TITLE
fix(UI): MainScene UI 레이아웃 보정

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -30635,7 +30635,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 170}
+  m_SizeDelta: {x: 1321.4, y: 251.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1865071036
 MonoBehaviour:
@@ -33547,10 +33547,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1865071033}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -0.000080109}
-  m_SizeDelta: {x: 1600, y: 300}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2016120987
 MonoBehaviour:
@@ -33572,7 +33572,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\uB2E4\uC2DC"
+  m_text: "\uB2E4\uC2DC \uBF51\uAE30"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}
   m_sharedMaterial: {fileID: -1657904361312498901, guid: 87276d374b71e2b4daaad50165516f5b, type: 2}


### PR DESCRIPTION
## 개요
MainScene의 UI 레이아웃 보정 (앵커/사이즈 등 RectTransform 값 조정).

## 변경 사항
- `Assets/Scenes/MainScene.unity` — UI 레이아웃 보정

🤖 Generated with [Claude Code](https://claude.com/claude-code)