### PR TITLE
fix: 코드 리뷰 지적사항 반영 - 인스펙터/역직렬화 null 요소 방어

### DIFF
--- a/ChaosChess_v2/Assets/Script/Map/MapManager.cs
+++ b/ChaosChess_v2/Assets/Script/Map/MapManager.cs
@@ -251,7 +251,7 @@ public class MapManager : MonoBehaviour
                         isCleared = nodeData.isCleared,
                         floor = nodeData.floor,
                         column = nodeData.column,
-                        nextColumns = new System.Collections.Generic.List<int>(nodeData.nextColumns),
+                        nextColumns = nodeData.nextColumns != null ? new System.Collections.Generic.List<int>(nodeData.nextColumns) : new System.Collections.Generic.List<int>(),
                         isAccessible = nodeData.isAccessible,
                         uiPosition = new UnityEngine.Vector2(nodeData.uiPositionX, nodeData.uiPositionY),
                         nodeType = (NodeType)nodeData.nodeType

--- a/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
+++ b/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
@@ -62,7 +62,7 @@ public class ButtonCanvas : ButtonParent
         int animIndex = 0;
         for (int i = 0; i < animationButtons.Count; i++)
         {
-            if (!animationButtons[i].gameObject.activeInHierarchy) continue;
+            if (animationButtons[i] == null || !animationButtons[i].gameObject.activeInHierarchy) continue;
             animationButtons[i].StartAnimation(animIndex * uiAnimDelay);
             animIndex++;
         }

--- a/ChaosChess_v2/Assets/Script/UI/CardBook/CardTargetUI.cs
+++ b/ChaosChess_v2/Assets/Script/UI/CardBook/CardTargetUI.cs
@@ -51,19 +51,28 @@ public class CardTargetUI : MonoBehaviour
             Sprite icon = pieceIconSet != null ? pieceIconSet.GetIcon(flag, data.PieceTargetColor) : null;
             if (icon == null) continue;
 
-            pieceIconSlots[slotIndex].sprite = icon;
-            pieceIconSlots[slotIndex].gameObject.SetActive(true);
+            if (pieceIconSlots[slotIndex] != null)
+            {
+                pieceIconSlots[slotIndex].sprite = icon;
+                pieceIconSlots[slotIndex].gameObject.SetActive(true);
+            }
             slotIndex++;
         }
 
         for (int i = slotIndex; i < pieceIconSlots.Length; i++)
-            pieceIconSlots[i].gameObject.SetActive(false);
+        {
+            if (pieceIconSlots[i] != null)
+                pieceIconSlots[i].gameObject.SetActive(false);
+        }
     }
 
     private void ShowLabel(string text)
     {
         foreach (var slot in pieceIconSlots)
-            slot.gameObject.SetActive(false);
+        {
+            if (slot != null)
+                slot.gameObject.SetActive(false);
+        }
 
         if (typeLabel != null)
         {

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardHandLayout.cs
@@ -95,6 +95,8 @@ public class CardHandLayout : MonoBehaviour
 
     private void Refresh(bool animate)
     {
+        _cards.RemoveAll(card => card == null);
+
         int n = _cards.Count;
         if (n == 0) return;
 
@@ -104,8 +106,6 @@ public class CardHandLayout : MonoBehaviour
 
         for (int i = 0; i < n; i++)
         {
-            if (_cards[i] == null) continue;
-
             float x = startX + i * overlap;
             _cards[i].DOKill();
             if (animate)


### PR DESCRIPTION
## 개요
PR #233 재검토 라운드에서 추가된 gemini-code-assist 리뷰 중, 인스펙터/역직렬화 시 null 요소로 인한 예외 가능성을 방어합니다.

## 변경 사항
- **MapManager**: `nextColumns` 역직렬화 결과가 null일 때 `List<int>` 생성자의 `ArgumentNullException` 방어
- **CardHandLayout**: `Refresh` 시작부에서 null 카드를 선제 정리하여 `_cards[0]` 접근 시 NRE 방어 (기존 루프 내 중복 가드 제거)
- **CardTargetUI**: `pieceIconSlots` 배열의 null 슬롯 가드
- **ButtonCanvas**: `animationButtons` 리스트의 null 요소 가드

## 비고
- `TimeBombCard.cs` / `Player.cs` 관련 리뷰는 전제가 현재 코드와 다르거나(타일 이펙터 누수 유발) 컨벤션과 충돌하여 의도적으로 미반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)