### PR TITLE
[Chore] release-drafter 설정 부트스트랩

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,98 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# develop(draft 누적), release/*(RC 프리릴리스), main(정식 publish) 모두 허용
+branches:
+  - develop
+  - 'release/*'
+  - main
+
+# PR 라벨 → 노트 카테고리(한글 제목). 내부 변경/수정도 라벨만 붙이면 그대로 들어간다.
+categories:
+  - title: '✨ 새로운 기능'
+    labels:
+      - 'feat'
+      - 'feature'
+      - 'enhancement'
+  - title: '🔄 기능 수정'
+    labels:
+      - 'modify'
+  - title: '🐛 버그 수정'
+    labels:
+      - 'fix'
+      - 'bugfix'
+  - title: '♻️ 리팩토링'
+    labels:
+      - 'refactor'
+  - title: '🗑️ 삭제'
+    labels:
+      - 'remove'
+  - title: '📝 문서'
+    labels:
+      - 'docs'
+
+# 어떤 카테고리에도 안 잡힌 PR은 이 섹션으로 (누락 방지)
+category-template: '$TITLE'
+
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+# 라벨 → SemVer 증가 규칙 (정식 출시 전이라 0.x 유지)
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking'
+  minor:
+    labels:
+      - 'feat'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'modify'
+      - 'refactor'
+      - 'remove'
+      - 'docs'
+  default: patch
+
+# PR 제목/브랜치 이름으로 라벨 자동 부여 → 커밋 컨벤션 그대로 라벨에 매핑
+autolabeler:
+  - label: 'feat'
+    branch:
+      - '/^feature\/.+/'
+    title:
+      - '/^feat/i'
+      - '/^add/i'
+  - label: 'fix'
+    branch:
+      - '/^fix\/.+/'
+      - '/^bugfix\/.+/'
+    title:
+      - '/^fix/i'
+  - label: 'modify'
+    title:
+      - '/^modify/i'
+  - label: 'refactor'
+    branch:
+      - '/^refactor\/.+/'
+    title:
+      - '/^refactor/i'
+  - label: 'remove'
+    title:
+      - '/^remove/i'
+  - label: 'docs'
+    title:
+      - '/^docs/i'
+
+template: |
+  ## 변경 사항
+
+  $CHANGES
+
+  **전체 변경 내역**: $PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,9 +39,6 @@ categories:
       - 'performance'
       - 'test'
 
-# 어떤 카테고리에도 안 잡힌 PR은 이 섹션으로 (누락 방지)
-category-template: '$TITLE'
-
 exclude-labels:
   - 'skip-changelog'
 
@@ -76,10 +73,12 @@ version-resolver:
   default: patch
 
 # PR 제목/브랜치 이름으로 라벨 자동 부여 → 커밋 컨벤션 그대로 라벨에 매핑
+# branch/title은 각각 별도 블록으로 분리 → 둘 중 하나만 만족해도 라벨 부여(OR)
 autolabeler:
   - label: 'feat'
     branch:
       - '/^feature\/.+/'
+  - label: 'feat'
     title:
       - '/^feat/i'
       - '/^add/i'
@@ -89,6 +88,7 @@ autolabeler:
     branch:
       - '/^fix\/.+/'
       - '/^bugfix\/.+/'
+  - label: 'fix'
     title:
       - '/^fix/i'
       - '/^\[fix\]/i'
@@ -100,6 +100,7 @@ autolabeler:
   - label: 'refactor'
     branch:
       - '/^refactor\/.+/'
+  - label: 'refactor'
     title:
       - '/^refactor/i'
       - '/^\[refactor\]/i'
@@ -115,6 +116,7 @@ autolabeler:
   - label: 'chore'
     branch:
       - '/^chore\/.+/'
+  - label: 'chore'
     title:
       - '/^chore/i'
       - '/^\[chore\]/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,6 +21,7 @@ categories:
     labels:
       - 'fix'
       - 'bugfix'
+      - 'bug'
   - title: '♻️ 리팩토링'
     labels:
       - 'refactor'
@@ -30,6 +31,13 @@ categories:
   - title: '📝 문서'
     labels:
       - 'docs'
+      - 'documentation'
+  - title: '⚙️ 기타 및 설정'
+    labels:
+      - 'chore'
+      - 'style'
+      - 'performance'
+      - 'test'
 
 # 어떤 카테고리에도 안 잡힌 PR은 이 섹션으로 (누락 방지)
 category-template: '$TITLE'
@@ -55,10 +63,16 @@ version-resolver:
     labels:
       - 'fix'
       - 'bugfix'
+      - 'bug'
       - 'modify'
       - 'refactor'
       - 'remove'
       - 'docs'
+      - 'documentation'
+      - 'chore'
+      - 'style'
+      - 'performance'
+      - 'test'
   default: patch
 
 # PR 제목/브랜치 이름으로 라벨 자동 부여 → 커밋 컨벤션 그대로 라벨에 매핑
@@ -69,26 +83,41 @@ autolabeler:
     title:
       - '/^feat/i'
       - '/^add/i'
+      - '/^\[feature\]/i'
+      - '/^\[feat\]/i'
   - label: 'fix'
     branch:
       - '/^fix\/.+/'
       - '/^bugfix\/.+/'
     title:
       - '/^fix/i'
+      - '/^\[fix\]/i'
+      - '/^\[bug\]/i'
   - label: 'modify'
     title:
       - '/^modify/i'
+      - '/^\[modify\]/i'
   - label: 'refactor'
     branch:
       - '/^refactor\/.+/'
     title:
       - '/^refactor/i'
+      - '/^\[refactor\]/i'
   - label: 'remove'
     title:
       - '/^remove/i'
+      - '/^\[remove\]/i'
   - label: 'docs'
     title:
       - '/^docs/i'
+      - '/^\[docs\]/i'
+      - '/^\[documentation\]/i'
+  - label: 'chore'
+    branch:
+      - '/^chore\/.+/'
+    title:
+      - '/^chore/i'
+      - '/^\[chore\]/i'
 
 template: |
   ## 변경 사항


### PR DESCRIPTION
# 개요
release-drafter 릴리스 자동화가 동작하려면 설정 파일(`.github/release-drafter.yml`)이 **기본 브랜치(main)** 에 존재해야 합니다. release-drafter는 PR 대상 브랜치와 무관하게 설정을 항상 기본 브랜치에서만 읽기 때문입니다.

현재 설정 파일이 feature 브랜치에만 있어 #236 의 CI(release-drafter)가 "Configuration file not found" 로 실패합니다. 이를 해결하기 위한 부트스트랩 PR입니다.

# 내용
## 릴리스 자동화 설정
- `.github/release-drafter.yml` 설정 파일을 main에 추가

# 기타 사항
- 워크플로 파일(rc/publish 등)은 의도적으로 포함하지 않았습니다. `release-publish.yml`은 main push 시 정식 릴리스를 publish하므로, 버전 기능이 실제로 main에 승격되기 전에 미리 트리거되지 않도록 정상 흐름(develop → release → main)으로 함께 올라갑니다.
- 이 PR 머지 후 #236 의 release-drafter 체크가 정상 통과합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@