### PR TITLE
[Fix] 에디터 버전 라벨 git 태그 반영

### DIFF
--- a/ChaosChess_v2/Assets/Editor/VersionStamp.cs
+++ b/ChaosChess_v2/Assets/Editor/VersionStamp.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -14,7 +12,7 @@ public class VersionStamp : IPreprocessBuildWithReport
 
     public void OnPreprocessBuild(BuildReport report)
     {
-        string version = ResolveVersionFromGit();
+        string version = GitVersion.Resolve();
         if (string.IsNullOrEmpty(version))
         {
             UnityEngine.Debug.LogWarning(
@@ -24,69 +22,5 @@ public class VersionStamp : IPreprocessBuildWithReport
 
         PlayerSettings.bundleVersion = version;
         UnityEngine.Debug.Log($"[VersionStamp] bundleVersion = {version}");
-    }
-
-    // 예: 태그 v0.3.1 위 → "0.3.1", 태그 이후 2커밋 → "0.3.1+2.g1a2b3c"
-    private static string ResolveVersionFromGit()
-    {
-        string raw = RunGit("describe --tags --always --dirty");
-        if (string.IsNullOrEmpty(raw))
-            return null;
-
-        raw = raw.Trim().TrimStart('v', 'V');
-
-        // -dirty 접미사를 먼저 떼어낸다 (작업트리에 커밋 안 된 변경이 있을 때 git이 붙임).
-        bool isDirty = raw.EndsWith("-dirty");
-        if (isDirty)
-            raw = raw.Substring(0, raw.Length - "-dirty".Length);
-
-        // git describe 형식 "<tag>-<count>-g<hash>"에서 커밋수/해시 접미사만 분리한다.
-        // 프리릴리스 태그(예: 0.3.0-rc.1)의 "-rc.1"은 태그 일부이므로 건드리지 않는다.
-        // → rc 버전이 SemVer 우선순위에서 정식판과 동일 취급되는 버그를 막는다.
-        var match = Regex.Match(raw, @"^(.*)-(\d+)-g([0-9a-fA-F]+)$");
-        string version = match.Success
-            ? $"{match.Groups[1].Value}+{match.Groups[2].Value}.g{match.Groups[3].Value}"
-            : raw;
-
-        if (isDirty)
-            version = version.Contains("+") ? $"{version}.dirty" : $"{version}+dirty";
-
-        return version;
-    }
-
-    private static string RunGit(string args)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", args)
-            {
-                WorkingDirectory = Application.dataPath, // .../Assets — git이 상위로 거슬러 찾음
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null)
-                return null;
-
-            // 타임아웃을 먼저 건다. 멈춘 프로세스를 죽이지 않고 ExitCode에 접근하면
-            // InvalidOperationException이 나므로, 타임아웃 시 강제 종료 후 빠진다.
-            if (!process.WaitForExit(3000))
-            {
-                process.Kill();
-                return null;
-            }
-
-            // git describe 출력은 짧아 WaitForExit 이후 읽어도 버퍼 데드락 위험이 없다.
-            string output = process.StandardOutput.ReadToEnd();
-            return process.ExitCode == 0 ? output : null;
-        }
-        catch
-        {
-            // git 미설치 등 — 빌드를 막지 않는다.
-            return null;
-        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/GitVersion.cs
+++ b/ChaosChess_v2/Assets/Script/UI/GitVersion.cs
@@ -1,0 +1,75 @@
+#if UNITY_EDITOR
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+// Git 태그에서 SemVer 버전 문자열을 만든다.
+// 빌드 훅(VersionStamp)과 에디터 표시(VersionLabel)가 동일한 규칙을 쓰도록
+// 해석 로직을 한곳에 모은다. 에디터 전용 — 빌드된 런타임에는 포함되지 않는다.
+public static class GitVersion
+{
+    // 예: 태그 v0.3.1 위 → "0.3.1", 태그 이후 2커밋 → "0.3.1+2.g1a2b3c"
+    public static string Resolve()
+    {
+        string raw = RunGit("describe --tags --always --dirty");
+        if (string.IsNullOrEmpty(raw))
+            return null;
+
+        raw = raw.Trim().TrimStart('v', 'V');
+
+        // -dirty 접미사를 먼저 떼어낸다 (작업트리에 커밋 안 된 변경이 있을 때 git이 붙임).
+        bool isDirty = raw.EndsWith("-dirty");
+        if (isDirty)
+            raw = raw.Substring(0, raw.Length - "-dirty".Length);
+
+        // git describe 형식 "<tag>-<count>-g<hash>"에서 커밋수/해시 접미사만 분리한다.
+        // 프리릴리스 태그(예: 0.3.0-rc.1)의 "-rc.1"은 태그 일부이므로 건드리지 않는다.
+        // → rc 버전이 SemVer 우선순위에서 정식판과 동일 취급되는 버그를 막는다.
+        var match = Regex.Match(raw, @"^(.*)-(\d+)-g([0-9a-fA-F]+)$");
+        string version = match.Success
+            ? $"{match.Groups[1].Value}+{match.Groups[2].Value}.g{match.Groups[3].Value}"
+            : raw;
+
+        if (isDirty)
+            version = version.Contains("+") ? $"{version}.dirty" : $"{version}+dirty";
+
+        return version;
+    }
+
+    private static string RunGit(string args)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", args)
+            {
+                WorkingDirectory = Application.dataPath, // .../Assets — git이 상위로 거슬러 찾음
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process == null)
+                return null;
+
+            // 타임아웃을 먼저 건다. 멈춘 프로세스를 죽이지 않고 ExitCode에 접근하면
+            // InvalidOperationException이 나므로, 타임아웃 시 강제 종료 후 빠진다.
+            if (!process.WaitForExit(3000))
+            {
+                process.Kill();
+                return null;
+            }
+
+            // git describe 출력은 짧아 WaitForExit 이후 읽어도 버퍼 데드락 위험이 없다.
+            string output = process.StandardOutput.ReadToEnd();
+            return process.ExitCode == 0 ? output : null;
+        }
+        catch
+        {
+            // git 미설치 등 — 빌드를 막지 않는다.
+            return null;
+        }
+    }
+}
+#endif

--- a/ChaosChess_v2/Assets/Script/UI/GitVersion.cs
+++ b/ChaosChess_v2/Assets/Script/UI/GitVersion.cs
@@ -8,8 +8,26 @@ using UnityEngine;
 // 해석 로직을 한곳에 모은다. 에디터 전용 — 빌드된 런타임에는 포함되지 않는다.
 public static class GitVersion
 {
+    // 해석 결과를 도메인 리로드 단위로 캐싱한다.
+    // VersionLabel은 [ExecuteAlways]라 OnValidate/OnEnable 등으로 Refresh가 잦은데,
+    // 그때마다 git 프로세스를 띄우면 에디터가 버벅인다(미설치 환경에선 매번 예외).
+    // static은 스크립트 리컴파일(도메인 리로드) 시 자동 초기화되므로,
+    // 버전이 바뀔 만한 시점(리컴파일)마다 자연히 다시 해석된다.
+    private static bool _resolved;
+    private static string _cached;
+
     // 예: 태그 v0.3.1 위 → "0.3.1", 태그 이후 2커밋 → "0.3.1+2.g1a2b3c"
     public static string Resolve()
+    {
+        if (_resolved)
+            return _cached;
+
+        _cached = ResolveFromGit();
+        _resolved = true;
+        return _cached;
+    }
+
+    private static string ResolveFromGit()
     {
         string raw = RunGit("describe --tags --always --dirty");
         if (string.IsNullOrEmpty(raw))

--- a/ChaosChess_v2/Assets/Script/UI/GitVersion.cs.meta
+++ b/ChaosChess_v2/Assets/Script/UI/GitVersion.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3fcd83d49b0b3144eb3a9ba02493ec10

--- a/ChaosChess_v2/Assets/Script/UI/VersionLabel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/VersionLabel.cs
@@ -28,7 +28,23 @@ public class VersionLabel : MonoBehaviour
         if (label == null)
             return;
 
-        string text = $"{prefix}{Application.version}";
+        // 런타임(빌드)은 빌드 시 각인된 Application.version을 쓴다.
+        // 에디터는 빌드 훅이 돌지 않아 bundleVersion이 옛 값에 머무르므로,
+        // git 태그를 직접 읽어 표시한다(표시용일 뿐 bundleVersion은 건드리지 않음).
+        string version = Application.version;
+#if UNITY_EDITOR
+        string gitVersion = GitVersion.Resolve();
+        if (!string.IsNullOrEmpty(gitVersion))
+        {
+            // 에디터는 작업 중이라 거의 항상 dirty/커밋앞섬 상태다.
+            // 빌드 메타데이터('+' 뒤: +dirty, +2.g1a2b3c 등)는 표시 노이즈이므로 떼어내
+            // 태그 버전(프리릴리스 -rc.1 등은 '+' 앞이라 보존)만 보여준다.
+            int meta = gitVersion.IndexOf('+');
+            version = meta >= 0 ? gitVersion.Substring(0, meta) : gitVersion;
+        }
+#endif
+
+        string text = $"{prefix}{version}";
         if (label.text != text)
             label.text = text;
     }


### PR DESCRIPTION
# 개요
에디터에서 버전 라벨이 실제 git 태그(예: v0.1.0)가 아니라 기본값(v1.0)으로 표시되던 문제를 수정한다.

# 내용
## 원인
VersionStamp는 빌드 직전(OnPreprocessBuild)에만 git 태그를 PlayerSettings.bundleVersion에 각인한다. 에디터에서는 빌드 훅이 돌지 않아 bundleVersion이 기본값에 머물렀고, VersionLabel이 읽는 Application.version도 그 값이라 실제 태그와 어긋났다.

## 수정
- git 태그 → SemVer 해석 로직을 GitVersion 헬퍼(에디터 전용)로 분리
- VersionStamp는 중복 로직을 제거하고 GitVersion.Resolve() 사용
- VersionLabel은 에디터에서 git 태그를 직접 읽어 표시(런타임/빌드는 기존대로 Application.version 사용). bundleVersion은 건드리지 않아 작업트리가 dirty 해지는 부작용 없음
- 에디터는 작업 중 거의 항상 dirty 상태라, 표시용 메타데이터(+dirty, +N.g해시)는 떼고 태그 버전만 노출(프리릴리스 -rc.1 등은 보존)

# 기타 사항
- 컴파일 검증은 에디터에서 확인 필요(Play Mode/빌드 제약상 직접 검증 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)