### PR TITLE
[Feat] 직전 수 하이라이트 표시 및 모바일 AI 수 딜레이 추가

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -2246,6 +2246,155 @@ MonoBehaviour:
   OnPanelDisabled:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &267020844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 267020845}
+  - component: {fileID: 267020847}
+  - component: {fileID: 267020846}
+  m_Layer: 0
+  m_Name: LastSelectBoard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &267020845
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 267020844}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4, y: -4, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1309221203}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!483693784 &267020846
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 267020844}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 837405885
+  m_SortingLayer: -1
+  m_SortingOrder: 1
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!1839735485 &267020847
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 267020844}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray:
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileSpriteArray:
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  m_TileMatrixArray:
+  - m_RefCount: 0
+    m_Data:
+      e00: 3.6232e-41
+      e01: 0
+      e02: 1e-45
+      e03: -9.500015
+      e10: 1e-45
+      e11: 0
+      e12: 0
+      e13: 5.69e-43
+      e20: 1.5975987e+25
+      e21: -9.500015
+      e22: 1.6706206e+29
+      e23: 2.3169763e-19
+      e30: 4.5914e-41
+      e31: 5.69e-43
+      e32: 5.73e-43
+      e33: 5.7e-43
+  m_TileColorArray:
+  - m_RefCount: 0
+    m_Data: {r: 1.65e-43, g: 1.65e-43, b: 1.65e-43, a: 1.65e-43}
+  - m_RefCount: 0
+    m_Data: {r: 2.316966e-19, g: 2.316966e-19, b: 2.316966e-19, a: 2.316966e-19}
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 0.5882353}
+  m_Origin: {x: -4, y: -4, z: 0}
+  m_Size: {x: 8, y: 13, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
 --- !u!1 &284765915
 GameObject:
   m_ObjectHideFlags: 0
@@ -9355,6 +9504,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1024790914}
+  - {fileID: 267020845}
   - {fileID: 891790252}
   - {fileID: 81987909}
   - {fileID: 1170031622}
@@ -9577,6 +9727,8 @@ MonoBehaviour:
   SelectTile: {fileID: 11400000, guid: 9523c4d553996d148a094f0f3aab6732, type: 2}
   MoveTile: {fileID: 11400000, guid: 62a53786bd4cc6c4db98665423525238, type: 2}
   CaptureTile: {fileID: 11400000, guid: 5cf46e4da3ae88d43adfcc7529c75573, type: 2}
+  LastMoveBoard: {fileID: 267020847}
+  LastMoveTile: {fileID: 11400000, guid: 45d467bd40f011b449c184e90d796b27, type: 2}
 --- !u!114 &1388470024
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -106,6 +106,13 @@ public class BoardManager : MonoBehaviour
     private Castling castling = new Castling();
     private Vector3Int enPassantPos = new Vector3Int(-1, -1, -1);
 
+    /// <summary>직전 수의 출발/도착 칸. 수가 없으면 (-1,-1,-1).</summary>
+    public Vector3Int LastMoveFrom { get; private set; } = new Vector3Int(-1, -1, -1);
+    public Vector3Int LastMoveTo { get; private set; } = new Vector3Int(-1, -1, -1);
+
+    /// <summary>직전 수가 바뀔 때 (from, to)를 통지합니다. 하이라이트 UI가 구독합니다.</summary>
+    public event System.Action<Vector3Int, Vector3Int> OnLastMoveChanged;
+
     [SerializeField] private string FEN;
     private List<Piece> Pieces = new List<Piece>();
     private Piece[,] board = new Piece[8, 8];
@@ -223,6 +230,10 @@ public class BoardManager : MonoBehaviour
         UpdateFEN();
 
         FairyStockfishBridge.Instance.SetPosition(FEN);
+
+        // 새 보드 상태 → 직전 수 초기화 및 하이라이트 제거 통지
+        LastMoveFrom = LastMoveTo = new Vector3Int(-1, -1, -1);
+        OnLastMoveChanged?.Invoke(LastMoveFrom, LastMoveTo);
 
         CheckKingExistence();
     }
@@ -465,6 +476,12 @@ public class BoardManager : MonoBehaviour
         {
             eff.OnPieceMove(target);
         }
+
+        // 직전 수 기록. 캐슬링 룩은 안쪽 재귀에서 먼저 통지되고,
+        // 바깥(킹) 호출이 마지막에 덮어쓰므로 최종값은 킹의 from/to가 된다.
+        LastMoveFrom = from;
+        LastMoveTo = target;
+        OnLastMoveChanged?.Invoke(from, target);
 
         return true;
     }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardUI.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardUI.cs
@@ -10,8 +10,13 @@ public class BoardUI : MonoBehaviour
     [SerializeField] private TileBase MoveTile;
     [SerializeField] private TileBase CaptureTile;
 
+    [Header("직전 수 하이라이트 (전용 레이어)")]
+    [SerializeField] private Tilemap LastMoveBoard;
+    [SerializeField] private TileBase LastMoveTile;
+
     private Vector3Int prvMouseCellPos;
     private List<Vector3Int> drawnMoveTilePositions = new List<Vector3Int>();
+    private readonly List<Vector3Int> lastMoveTilePositions = new List<Vector3Int>();
 
     public void DrawSelectTile(Vector3Int pos)
     {
@@ -77,5 +82,34 @@ public class BoardUI : MonoBehaviour
 
             drawnMoveTilePositions.Add(pos);
         }
+    }
+
+    /// <summary>직전 수의 출발/도착 칸을 전용 레이어에 하이라이트합니다.
+    /// 좌표가 유효하지 않으면(예: -1) 해당 칸은 칠하지 않으므로, (-1,-1)을 넘기면 클리어만 수행됩니다.</summary>
+    public void DrawLastMove(Vector3Int from, Vector3Int to)
+    {
+        ClearLastMove();
+        StampLastMove(from);
+        StampLastMove(to);
+    }
+
+    private void StampLastMove(Vector3Int pos)
+    {
+        if (LastMoveBoard == null || LastMoveTile == null) return;
+        if (pos.x < 0 || pos.y < 0) return;
+
+        LastMoveBoard.SetTile(pos, LastMoveTile);
+        LastMoveBoard.SetTileFlags(pos, TileFlags.None);
+        lastMoveTilePositions.Add(pos);
+    }
+
+    public void ClearLastMove()
+    {
+        if (LastMoveBoard != null)
+        {
+            foreach (Vector3Int pos in lastMoveTilePositions)
+                LastMoveBoard.SetTile(pos, null);
+        }
+        lastMoveTilePositions.Clear();
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -110,6 +110,12 @@ public class GameManager : MonoBehaviour
         BoardManager.Instance.OnPromotionRequired -= HandlePromotion;
         BoardManager.Instance.OnPromotionRequired += HandlePromotion;
 
+        if (boardUI != null)
+        {
+            BoardManager.Instance.OnLastMoveChanged -= boardUI.DrawLastMove;
+            BoardManager.Instance.OnLastMoveChanged += boardUI.DrawLastMove;
+        }
+
         OnTimeReversalRequired -= HandleTimeReversal;
         OnTimeReversalRequired += HandleTimeReversal;
 

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -517,6 +517,10 @@ public class GameManager : MonoBehaviour
             {
                 RunAfterMinAiDelay(requestTime, () =>
                 {
+                    // 지연 도중 씬 전환으로 인스턴스가 파괴되었을 수 있어 유효성 재확인
+                    if (this == null || BoardManager.Instance == null)
+                        return;
+
                     if (IsEndGame)
                         return;
 

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -7,6 +7,14 @@ public class GameManager : MonoBehaviour
 {
     private const int AiMoveTimeMs = 5000;
 
+    // 모바일에서는 엔진이 즉시 수를 반환해 AI가 너무 빠르게 두는 느낌을 주므로,
+    // 수를 적용하기 전 최소한의 연출 딜레이를 보장한다 (초 단위).
+#if UNITY_ANDROID || UNITY_IOS
+    private const float MinAiMoveDelaySeconds = 0.8f;
+#else
+    private const float MinAiMoveDelaySeconds = 0f;
+#endif
+
     public GameResult FinishType { get; set; } = GameResult.None;
 
     public static GameManager Instance;
@@ -494,21 +502,44 @@ public class GameManager : MonoBehaviour
         if (IsEndGame)
             return;
 
+        float requestTime = Time.realtimeSinceStartup;
+
         FairyStockfishBridge.Instance.GetBestMoveAsync(
             depth: 12,
             moveTimeMs: AiMoveTimeMs,
             callback: (uciMove) =>
             {
-                if (BoardManager.Instance.IsValidUciMove(uciMove))
+                RunAfterMinAiDelay(requestTime, () =>
                 {
-                    BoardManager.Instance.ApplyUCIMove(uciMove);
-                    return;
-                }
+                    if (IsEndGame)
+                        return;
 
-                Debug.LogWarning($"[AI] Stockfish returned invalid move '{uciMove}'. Using random legal fallback.");
-                ApplyFallbackLegalAIMove();
+                    if (BoardManager.Instance.IsValidUciMove(uciMove))
+                    {
+                        BoardManager.Instance.ApplyUCIMove(uciMove);
+                        return;
+                    }
+
+                    Debug.LogWarning($"[AI] Stockfish returned invalid move '{uciMove}'. Using random legal fallback.");
+                    ApplyFallbackLegalAIMove();
+                });
             }
         );
+    }
+
+    // 엔진 응답이 최소 연출 시간보다 빨리 도착하면 남은 시간만큼 지연 후 실행한다.
+    private void RunAfterMinAiDelay(float requestTime, Action action)
+    {
+        float elapsed = Time.realtimeSinceStartup - requestTime;
+        float remaining = MinAiMoveDelaySeconds - elapsed;
+
+        if (remaining <= 0f)
+        {
+            action();
+            return;
+        }
+
+        DOVirtual.DelayedCall(remaining, () => action(), ignoreTimeScale: true);
     }
 
     private void ApplyFallbackLegalAIMove()

--- a/ChaosChess_v2/Assets/Tilemap/New Tile Palette.prefab
+++ b/ChaosChess_v2/Assets/Tilemap/New Tile Palette.prefab
@@ -52,6 +52,16 @@ Tilemap:
       m_TileObjectToInstantiateIndex: 65535
       dummyAlignment: 0
       m_AllTileFlags: 1073741825
+  - first: {x: -3, y: 0, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 1
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
   - first: {x: -4, y: 1, z: 0}
     second:
       serializedVersion: 2
@@ -80,15 +90,17 @@ Tilemap:
     m_Data: {fileID: 11400000, guid: ccd9bd2b81194a443a53a04178c7a470, type: 2}
   - m_RefCount: 1
     m_Data: {fileID: 11400000, guid: 9523c4d553996d148a094f0f3aab6732, type: 2}
-  m_TileSpriteArray:
   - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 45d467bd40f011b449c184e90d796b27, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 2
     m_Data: {fileID: 5407276388446273561, guid: 8005fd67b092a404785cc915b51a0a17, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 1903702615, guid: 8005fd67b092a404785cc915b51a0a17, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: -1131124703, guid: 8005fd67b092a404785cc915b51a0a17, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 3
+  - m_RefCount: 4
     m_Data:
       e00: 1
       e01: 0
@@ -109,6 +121,8 @@ Tilemap:
   m_TileColorArray:
   - m_RefCount: 3
     m_Data: {r: 1, g: 1, b: 1, a: 1}
+  - m_RefCount: 1
+    m_Data: {r: 0.31132066, g: 1, b: 0.43801993, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -230,7 +244,7 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &2607940569004821337
+--- !u!114 &7644180249568048212
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/ChaosChess_v2/Assets/Tilemap/lastSelectBoard.asset
+++ b/ChaosChess_v2/Assets/Tilemap/lastSelectBoard.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: lastSelectBoard
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 5407276388446273561, guid: 8005fd67b092a404785cc915b51a0a17, type: 3}
+  m_Color: {r: 0.9293194, g: 1, b: 0, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/ChaosChess_v2/Assets/Tilemap/lastSelectBoard.asset.meta
+++ b/ChaosChess_v2/Assets/Tilemap/lastSelectBoard.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45d467bd40f011b449c184e90d796b27
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 개요

직전에 둔 수의 출발/도착 칸을 보드에 하이라이트하는 기능과, 모바일 환경에서 AI가 너무 빠르게 수를 두는 문제를 완화하는 최소 딜레이를 추가합니다.

# 내용

## 직전 수 하이라이트 (UI)

- `BoardManager`에 직전 수의 `LastMoveFrom`/`LastMoveTo` 상태와 `OnLastMoveChanged` 이벤트를 추가했습니다. 수 실행 시 출발/도착 칸을 기록하고 통지하며, 보드 상태가 새로 설정될 때 초기화합니다.
- `BoardUI`에 전용 타일맵 레이어(`LastMoveBoard`)에 하이라이트를 칠하고 지우는 `DrawLastMove`/`ClearLastMove`를 추가했습니다.
- `GameManager`가 `OnLastMoveChanged` → `BoardUI.DrawLastMove`를 구독하도록 연결했습니다.
- 하이라이트 전용 타일맵(`lastSelectBoard.asset`)과 씬·타일 팔레트 설정을 추가했습니다.

## 모바일 AI 수 딜레이 (Manager)

- PC는 엔진 탐색에 시간이 걸리지만 모바일(Android/iOS)은 엔진이 거의 즉시 콜백을 반환해 AI 수가 너무 빠르게 적용되는 문제가 있었습니다.
- `RequestAIMove`에서 요청 시각을 기록하고, 엔진 응답이 최소 연출 시간(모바일 0.8초)보다 빨리 도착하면 남은 시간만큼 지연 후 수를 적용하도록 했습니다. 이미 충분히 걸린 경우엔 추가 지연이 없습니다(PC는 0초로 기존 동작 유지).
- 지연 중 게임이 종료되거나 씬이 전환될 수 있어 적용 직전 `IsEndGame` 및 인스턴스 유효성을 재확인합니다.

# 기타 사항

- 딜레이 도중 실행은 `DOVirtual.DelayedCall`(`ignoreTimeScale`)을 사용합니다.
- 동작 검증은 에디터 플레이 테스트가 필요합니다(정적 분석으로만 확인). 특히 모바일 빌드에서 AI 딜레이 체감과 하이라이트 타일맵 연결을 확인해 주세요.
