### PR TITLE
[Feat] 카드 효과 VFX 프레임워크 및 UI 개선

### DIFF
--- a/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
+++ b/ChaosChess_v2/Assets/Editor/CardDataSOEditor.cs
@@ -37,6 +37,16 @@ public class CardDataSOEditor : Editor
     SerializedProperty limitTurn;
     SerializedProperty statusDisplayType;
 
+    // VFX 연출
+    SerializedProperty vfxApply;
+    SerializedProperty vfxLoop;
+    SerializedProperty vfxHook;
+    SerializedProperty vfxRevert;
+    SerializedProperty vfxPlayApplyAnim;
+    SerializedProperty vfxPlayHookAnim;
+    SerializedProperty vfxAnimStrength;
+    SerializedProperty vfxAnimDuration;
+
     // 부가 정보
     SerializedProperty needAdditionalDescription;
     SerializedProperty descriptionType;
@@ -48,6 +58,7 @@ public class CardDataSOEditor : Editor
 
     // 섹션 토글 상태
     bool showBaseInfo = true;
+    bool showVFX = true;
     bool showTypeSettings = true;
     bool showAdditionalInfo = true;
 
@@ -87,6 +98,16 @@ public class CardDataSOEditor : Editor
         limitTurn = serializedObject.FindProperty("LimitTurn");
         statusDisplayType = serializedObject.FindProperty("StatusDisplayType");
 
+        SerializedProperty vfx = serializedObject.FindProperty("VFX");
+        vfxApply = vfx.FindPropertyRelative("ApplyVFXPrefab");
+        vfxLoop = vfx.FindPropertyRelative("LoopVFXPrefab");
+        vfxHook = vfx.FindPropertyRelative("HookVFXPrefab");
+        vfxRevert = vfx.FindPropertyRelative("RevertVFXPrefab");
+        vfxPlayApplyAnim = vfx.FindPropertyRelative("PlayApplyAnim");
+        vfxPlayHookAnim = vfx.FindPropertyRelative("PlayHookAnim");
+        vfxAnimStrength = vfx.FindPropertyRelative("AnimStrength");
+        vfxAnimDuration = vfx.FindPropertyRelative("AnimDuration");
+
         needAdditionalDescription = serializedObject.FindProperty("NeedAdditionalDescription");
         descriptionType = serializedObject.FindProperty("DescriptionType");
         additionalDescriptionTitle = serializedObject.FindProperty("AdditionalDescriptionTitle");
@@ -117,6 +138,18 @@ public class CardDataSOEditor : Editor
                 EditorGUILayout.Space(4);
                 EditorGUILayout.PropertyField(statusDisplayType, new GUIContent("상태 표시 타입"));
                 DrawStatusDisplayPreview();
+            }
+        }
+
+        EditorGUILayout.Space(6);
+
+        // ── VFX 연출 설정 ───────────────────────────────
+        showVFX = DrawSectionHeader("VFX 연출 설정", showVFX);
+        if (showVFX)
+        {
+            using (new EditorGUILayout.VerticalScope(sectionBoxStyle))
+            {
+                DrawVFXFields();
             }
         }
 
@@ -167,6 +200,32 @@ public class CardDataSOEditor : Editor
         serializedObject.ApplyModifiedProperties();
     }
 
+    // ── VFX 연출 필드 렌더링 ─────────────────────────────
+    void DrawVFXFields()
+    {
+        HelpBox("효과 적용/유지/소멸 및 게임 훅 발동 시 재생할 파티클·트윈 연출입니다. 비워두면 해당 시점 연출은 생략됩니다.", MessageType.None);
+
+        EditorGUILayout.Space(4);
+        using (new EditorGUILayout.VerticalScope(subSectionBoxStyle))
+        {
+            EditorGUILayout.LabelField("파티클 프리팹", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(vfxApply, new GUIContent("적용 시 (1회)"));
+            EditorGUILayout.PropertyField(vfxLoop, new GUIContent("유지 중 (루프)"));
+            EditorGUILayout.PropertyField(vfxHook, new GUIContent("훅 발동 시 (1회)"));
+            EditorGUILayout.PropertyField(vfxRevert, new GUIContent("소멸 시 (1회)"));
+        }
+
+        EditorGUILayout.Space(4);
+        using (new EditorGUILayout.VerticalScope(subSectionBoxStyle))
+        {
+            EditorGUILayout.LabelField("기본 트윈 (펀치/스케일)", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(vfxPlayApplyAnim, new GUIContent("적용 시 펀치"));
+            EditorGUILayout.PropertyField(vfxPlayHookAnim, new GUIContent("훅 시 펀치"));
+            EditorGUILayout.PropertyField(vfxAnimStrength, new GUIContent("펀치 세기"));
+            EditorGUILayout.PropertyField(vfxAnimDuration, new GUIContent("펀치 진행 시간(초)"));
+        }
+    }
+
     // ── 타입별 필드 렌더링 ───────────────────────────────
     void DrawTypeSpecificFields(CardType type)
     {
@@ -202,6 +261,10 @@ public class CardDataSOEditor : Editor
             EditorGUILayout.HelpBox("-1 : 턴 제한 없이 계속 유지됩니다.", MessageType.Warning);
         }
         EditorGUILayout.PropertyField(requiredPieceCount, new GUIContent("필요 기물 수"));
+
+        EditorGUILayout.Space(6);
+        HelpBox("효과 범위를 타일로 표시하려면 아래에서 타일을 지정하세요. (예: 무하한 3x3 범위)", MessageType.None);
+        DrawTileEffectFields();
     }
 
     void DrawTileFields()

--- a/ChaosChess_v2/Assets/Materials/MainBGMAT.mat
+++ b/ChaosChess_v2/Assets/Materials/MainBGMAT.mat
@@ -74,6 +74,6 @@ Material:
     - _Dir: {r: 0, g: 0, b: 0, a: 0}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
     - _ScreenParams: {r: 0, g: 0, b: 0, a: 0}
-    - _TileOffset: {r: 0.23104264, g: 0.5, b: 0, a: 0}
+    - _TileOffset: {r: 0.23316061, g: 0.5, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -9729,6 +9729,7 @@ MonoBehaviour:
   CaptureTile: {fileID: 11400000, guid: 5cf46e4da3ae88d43adfcc7529c75573, type: 2}
   LastMoveBoard: {fileID: 267020847}
   LastMoveTile: {fileID: 11400000, guid: 45d467bd40f011b449c184e90d796b27, type: 2}
+  BlockedMoveTile: {fileID: 11400000, guid: da4a65c4809a7c0408dfec003b0e5190, type: 2}
 --- !u!114 &1388470024
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainScene.unity
@@ -2128,6 +2128,139 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 177556868}
   m_CullTransparentMesh: 1
+--- !u!1 &180167314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 180167318}
+  - component: {fileID: 180167317}
+  - component: {fileID: 180167316}
+  - component: {fileID: 180167315}
+  - component: {fileID: 180167319}
+  - component: {fileID: 180167320}
+  m_Layer: 5
+  m_Name: SplashCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &180167315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &180167316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &180167317
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 2069823172}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 1
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: -344459325
+  m_SortingOrder: 999
+  m_TargetDisplay: 0
+--- !u!224 &180167318
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 905444072}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!225 &180167319
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &180167320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180167314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74ff0678fe17a2c448efb9c394d5eada, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  logoImage: {fileID: 1493916406}
+  canvasGroup: {fileID: 180167319}
+  fadeDuration: 1
+  splashImageDuration: 0.75
+  canvasFadeDuration: 1
 --- !u!1 &181743022
 GameObject:
   m_ObjectHideFlags: 0
@@ -3179,6 +3312,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   OnCanvasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFadeComplete:
     m_PersistentCalls:
       m_Calls: []
   tierGroups:
@@ -8542,12 +8678,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isMainParent: 1
   fadeDuration: 0.2
-  uiAnimDelay: 0.2
+  uiAnimDelay: 0
   animationButtons: []
   OnCanvasEnabled:
     m_PersistentCalls:
       m_Calls: []
   OnCanvasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  OnFadeComplete:
     m_PersistentCalls:
       m_Calls: []
 --- !u!225 &568138796
@@ -8860,6 +8999,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  OnFadeComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &579454196
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14460,6 +14602,82 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 883368237}
+  m_CullTransparentMesh: 1
+--- !u!1 &905444071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 905444072}
+  - component: {fileID: 905444074}
+  - component: {fileID: 905444073}
+  m_Layer: 5
+  m_Name: Rect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &905444072
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905444071}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1493916405}
+  m_Father: {fileID: 180167318}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &905444073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905444071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &905444074
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 905444071}
   m_CullTransparentMesh: 1
 --- !u!1 &910000000
 GameObject:
@@ -23029,6 +23247,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1474395587}
   m_CullTransparentMesh: 1
+--- !u!1 &1493916404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1493916405}
+  - component: {fileID: 1493916407}
+  - component: {fileID: 1493916406}
+  m_Layer: 5
+  m_Name: Logo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1493916405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493916404}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 905444072}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1080, y: 2414.6724}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1493916406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493916404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 82185ee7a978fe947881aa44bf718c04, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1493916407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493916404}
+  m_CullTransparentMesh: 1
 --- !u!1 &1496686527
 GameObject:
   m_ObjectHideFlags: 0
@@ -30251,6 +30544,9 @@ MonoBehaviour:
   OnCanvasDisabled:
     m_PersistentCalls:
       m_Calls: []
+  OnFadeComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!225 &1843443125
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -32404,6 +32700,9 @@ MonoBehaviour:
   OnCanvasDisabled:
     m_PersistentCalls:
       m_Calls: []
+  OnFadeComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!225 &1953392894
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -32876,7 +33175,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -36352,6 +36651,7 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 2069823173}
+  - {fileID: 180167318}
   - {fileID: 568138794}
   - {fileID: 1843443123}
   - {fileID: 579454194}

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -8,6 +8,35 @@ public enum TileEffectAnimationMode
     Turn
 }
 
+/// <summary>
+/// 카드 효과가 기물/타일에 적용될 때 재생할 파티클·트윈 연출 설정입니다.
+/// 프리팹을 비워두면 해당 시점 연출은 자동으로 생략됩니다.
+/// </summary>
+[System.Serializable]
+public class CardVFXConfig
+{
+    [Header("파티클 프리팹")]
+    [Tooltip("효과 적용 순간 1회 재생")]
+    public GameObject ApplyVFXPrefab;
+    [Tooltip("효과가 유지되는 동안 지속 재생(앵커에 부착되어 따라다님)")]
+    public GameObject LoopVFXPrefab;
+    [Tooltip("이동/잡기/타일 진입 등 게임 훅 발동 시 1회 재생")]
+    public GameObject HookVFXPrefab;
+    [Tooltip("효과 소멸 순간 1회 재생")]
+    public GameObject RevertVFXPrefab;
+
+    [Header("기본 트윈 연출 (펀치/스케일)")]
+    [Tooltip("적용 시 앵커에 펀치 스케일 재생")]
+    public bool PlayApplyAnim = true;
+    [Tooltip("훅 발동 시 앵커에 펀치 스케일 재생")]
+    public bool PlayHookAnim = true;
+    [Range(0f, 1f)]
+    public float AnimStrength = 0.2f;
+    [Tooltip("펀치 트윈 진행 시간(초)")]
+    [Min(0.01f)]
+    public float AnimDuration = 0.3f;
+}
+
 [CreateAssetMenu(fileName = "Card Data", menuName = "Card/Card Data")]
 public class CardDataSO : ScriptableObject
 {
@@ -19,6 +48,10 @@ public class CardDataSO : ScriptableObject
 
     public CardType Type;
     public Tier CardTier;
+
+    [Space(30)]
+    [Header("VFX 연출 설정")]
+    public CardVFXConfig VFX = new CardVFXConfig();
 
     // 기물 타입에 필요한 설정
     [Space(30)]

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -62,6 +62,7 @@ public abstract class Effector : MonoBehaviour, IEffect
         hasNotifiedApplied = true;
         OnAnyEffectApplied?.Invoke(this);
         OnEffectApplied();
+        PlayApplyVFX();
     }
 
     /// <summary>효과를 대상에서 제거합니다. 턴 이벤트를 해제하고 OnRevert()를 호출합니다.</summary>
@@ -77,6 +78,10 @@ public abstract class Effector : MonoBehaviour, IEffect
         bool shouldNotifyReverted = hasNotifiedApplied;
         hasNotifiedApplied = false;
 
+        StopLoopVFX();
+        if (shouldNotifyReverted)
+            PlayRevertVFX();
+
         OnRevert();
         if (shouldNotifyReverted)
             OnAnyEffectReverted?.Invoke(this);
@@ -88,6 +93,7 @@ public abstract class Effector : MonoBehaviour, IEffect
 
     protected virtual void OnDestroy()
     {
+        StopLoopVFX();
         if (!isApplied) return;
 
         isApplied = false;
@@ -203,6 +209,69 @@ public abstract class Effector : MonoBehaviour, IEffect
 
     /// <summary>선택 순서별 타일 연출 인덱스입니다. 필요 시 서브 클래스에서 재정의합니다.</summary>
     protected virtual int GetVisualEffectTileIndex() => 0;
+
+    // ───────── VFX 연출 (CardSO.VFX 기반 자동 재생) ─────────
+
+    private GameObject loopVFXInstance;
+
+    /// <summary>VFX 연출 기준 월드 좌표입니다. 서브클래스가 제공하지 않으면 위치 기반 연출(적용/유지/소멸)은 생략됩니다.</summary>
+    protected virtual bool TryGetVFXWorldPosition(out Vector3 pos) { pos = default; return false; }
+
+    /// <summary>루프 VFX를 부착하고 펀치를 적용할 대상입니다. 부착 대상이 파괴되면 루프도 함께 정리됩니다.</summary>
+    protected virtual Transform VFXFollowTarget => null;
+
+    /// <summary>효과 적용 시 1회 버스트 + 지속 루프 + 기본 펀치 트윈을 재생합니다.</summary>
+    private void PlayApplyVFX()
+    {
+        CardVFXConfig vfx = CardSO?.VFX;
+        if (vfx == null) return;
+        if (!TryGetVFXWorldPosition(out Vector3 pos)) return;
+
+        Transform follow = VFXFollowTarget;
+        VFXSpawner.SpawnOneShot(vfx.ApplyVFXPrefab, pos, follow);
+
+        if (vfx.LoopVFXPrefab != null)
+            loopVFXInstance = VFXSpawner.SpawnLoop(vfx.LoopVFXPrefab, pos, follow);
+
+        if (vfx.PlayApplyAnim)
+            VFXSpawner.PlayPunch(follow, vfx.AnimStrength, vfx.AnimDuration);
+    }
+
+    /// <summary>효과 소멸 시 1회 버스트를 재생합니다. 호스트가 곧 파괴돼도 살아남도록 부모 없이 스폰합니다.</summary>
+    private void PlayRevertVFX()
+    {
+        CardVFXConfig vfx = CardSO?.VFX;
+        if (vfx == null || vfx.RevertVFXPrefab == null) return;
+        if (!TryGetVFXWorldPosition(out Vector3 pos)) return;
+
+        VFXSpawner.SpawnOneShot(vfx.RevertVFXPrefab, pos, null);
+    }
+
+    /// <summary>지속 루프 VFX를 정리합니다.</summary>
+    private void StopLoopVFX()
+    {
+        if (loopVFXInstance == null) return;
+        Destroy(loopVFXInstance);
+        loopVFXInstance = null;
+    }
+
+    /// <summary>앵커 위치에 게임 훅 VFX를 재생합니다. 서브클래스 훅(이동/잡기/진입 등)에서 호출하세요.</summary>
+    protected void PlayHookVFX()
+    {
+        if (!TryGetVFXWorldPosition(out Vector3 pos)) return;
+        PlayHookVFX(pos, VFXFollowTarget);
+    }
+
+    /// <summary>지정 월드 좌표에 게임 훅 VFX를 재생합니다. 버스트는 부모 없이 스폰되어 대상 파괴(기물 잡힘 등)와 무관하게 유지됩니다.</summary>
+    protected void PlayHookVFX(Vector3 worldPos, Transform punchTarget = null)
+    {
+        CardVFXConfig vfx = CardSO?.VFX;
+        if (vfx == null) return;
+
+        VFXSpawner.SpawnOneShot(vfx.HookVFXPrefab, worldPos, null);
+        if (vfx.PlayHookAnim)
+            VFXSpawner.PlayPunch(punchTarget, vfx.AnimStrength, vfx.AnimDuration);
+    }
 }
 
 /// <summary>기물에 부착되는 효과의 기반 추상 클래스</summary>
@@ -240,9 +309,18 @@ public abstract class PieceEffector : Effector, IPieceEffect
         SetDuration(duration);
     }
 
-    public virtual void OnPieceCaptured() { }
-    public virtual void OnPieceCapture() { }
-    public virtual void OnPieceMove(Vector3Int dest) { }
+    protected override bool TryGetVFXWorldPosition(out Vector3 pos)
+    {
+        if (target == null) { pos = default; return false; }
+        pos = target.transform.position;
+        return true;
+    }
+
+    protected override Transform VFXFollowTarget => target != null ? target.transform : null;
+
+    public virtual void OnPieceCaptured() { PlayHookVFX(); }
+    public virtual void OnPieceCapture() { PlayHookVFX(); }
+    public virtual void OnPieceMove(Vector3Int dest) { PlayHookVFX(); }
 }
 
 /// <summary>타일에 부착되는 효과의 기반 추상 클래스</summary>
@@ -265,9 +343,18 @@ public abstract class TileEffector : Effector, ITileEffect
         SetDuration(duration);
     }
 
-    public virtual void OnPieceEnter(Piece piece) { }
-    public virtual void OnPieceExit(Piece piece) { }
+    public virtual void OnPieceEnter(Piece piece) { PlayHookVFX(); }
+    public virtual void OnPieceExit(Piece piece) { PlayHookVFX(); }
     public virtual bool CanPieceEnter(Piece piece, Vector3Int from, Vector3Int to) { return true; }
+
+    protected override bool TryGetVFXWorldPosition(out Vector3 pos)
+    {
+        if (BoardManager.Instance == null) { pos = default; return false; }
+        pos = BoardManager.Instance.GridPosToWorldPos(tilePos);
+        return true;
+    }
+
+    protected override Transform VFXFollowTarget => transform;
 
     public override void OnTurnChanged()
     {
@@ -357,7 +444,11 @@ public abstract class GlobalEffector : Effector
     /// <summary>조건에 맞는 기물이 이동하거나 잡을 때 호출됩니다.</summary>
     /// <param name="piece">행동한 기물</param>
     /// <param name="dest">이동한 목적지</param>
-    public virtual void OnPieceAct(Piece piece, Vector3Int dest) { }
+    public virtual void OnPieceAct(Piece piece, Vector3Int dest)
+    {
+        if (piece != null)
+            PlayHookVFX(piece.transform.position, piece.transform);
+    }
 
     /// <summary>조건에 맞는 기물이 다른 기물을 잡을 때 호출됩니다.</summary>
     /// <param name="piece">행동한 기물</param>

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.cs
@@ -318,7 +318,12 @@ public abstract class PieceEffector : Effector, IPieceEffect
 
     protected override Transform VFXFollowTarget => target != null ? target.transform : null;
 
-    public virtual void OnPieceCaptured() { PlayHookVFX(); }
+    public virtual void OnPieceCaptured()
+    {
+        // 잡혀서 곧 파괴될 기물이므로 펀치 트윈 없이 파티클 버스트만 재생합니다.
+        if (target != null)
+            PlayHookVFX(target.transform.position, null);
+    }
     public virtual void OnPieceCapture() { PlayHookVFX(); }
     public virtual void OnPieceMove(Vector3Int dest) { PlayHookVFX(); }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Effector/Effector.md
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/Effector.md
@@ -216,6 +216,60 @@ public void Execute(CardEffectArgs args)
 
 ---
 
+## VFX 연출 (파티클 + 트윈)
+
+효과가 적용/유지/소멸되거나 게임 훅이 발동할 때 파티클과 기본 펀치 트윈을 자동으로 재생합니다.
+연출 에셋은 카드별 `CardDataSO.VFX`(`CardVFXConfig`)에 직접 연결합니다.
+
+### CardDataSO.VFX 필드
+
+| 필드 | 재생 시점 |
+|---|---|
+| `ApplyVFXPrefab` | 효과 적용 순간 1회 버스트 |
+| `LoopVFXPrefab` | 효과 유지 중 지속 루프 (앵커에 부착되어 따라다님) |
+| `HookVFXPrefab` | 게임 훅(이동/잡기/진입 등) 발동 시 1회 버스트 |
+| `RevertVFXPrefab` | 효과 소멸 순간 1회 버스트 |
+| `PlayApplyAnim` / `PlayHookAnim` | 적용/훅 시 앵커에 펀치 스케일 트윈 재생 여부 |
+| `AnimStrength` | 펀치 세기 |
+| `AnimDuration` | 펀치 트윈 진행 시간(초) |
+
+> 프리팹을 비워두면 해당 시점 연출은 자동으로 생략됩니다. 기존 카드(미설정)는 동작 변화가 없습니다.
+
+### 자동 재생 (apply / loop / revert)
+
+베이스 `Effector`의 `Apply()` / `Revert()`에 통합되어 있어 **서브클래스가 따로 호출할 필요가 없습니다.**
+위치/부착 대상은 각 타입이 제공합니다.
+
+| 타입 | 앵커 위치 | 루프 부착 대상 |
+|---|---|---|
+| `PieceEffector` | `target.transform.position` | 기물 transform (이동 시 따라가고, 기물 파괴 시 자동 정리) |
+| `TileEffector` | `GridPosToWorldPos(tilePos)` | 호스트 GameObject (호스트 파괴 시 자동 정리) |
+| `GlobalEffector` | 없음 → apply/loop/revert 연출 생략 (훅 VFX만 사용) |
+
+루프 VFX는 앵커의 자식으로 붙으므로 정상 `Revert`·강제 `Destroy`(기물 잡힘 등) 양쪽에서 누수 없이 정리됩니다.
+
+### 훅 VFX (opt-in)
+
+게임 훅 VFX는 **서브클래스에서 호출**해야 합니다. 베이스 훅 메서드가 기본으로 `PlayHookVFX()`를 호출하므로,
+훅을 override할 때 `base.OnXxx()`를 호출하면 훅 VFX를 함께 얻습니다(호출하지 않으면 무시).
+
+```csharp
+public override void OnPieceMove(Vector3Int dest)
+{
+    base.OnPieceMove(dest);  // HookVFXPrefab 버스트 + 펀치
+    // 고유 로직...
+}
+```
+
+직접 위치를 지정하려면 `PlayHookVFX(Vector3 worldPos, Transform punchTarget = null)`를 사용합니다.
+훅 버스트는 부모 없이 스폰되어 대상 기물이 같은 프레임에 파괴돼도(잡힘) 정상 표시됩니다.
+
+### 스폰/정리
+
+`VFXSpawner`(정적 헬퍼)가 담당합니다. 풀링은 적용하지 않으며(추후 확장), 원샷은 파티클 수명이 끝나면 자동 파괴됩니다.
+
+---
+
 ## 턴 관리
 
 `OnTurnChanged()`는 `GameManager.NextTurn()` 호출 시 `OnAnyTurnChanged` 이벤트를 통해 **자동으로 호출**됩니다.  

--- a/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using DG.Tweening;
+
+/// <summary>
+/// 카드 효과용 파티클/트윈 연출을 스폰하고 정리하는 경량 정적 헬퍼입니다.
+/// 풀링은 적용하지 않으며(추후 확장 여지), 모든 메서드는 prefab/대상이 null이면 조용히 무시합니다.
+/// </summary>
+public static class VFXSpawner
+{
+    /// <summary>파티클 시스템이 없을 때 원샷 인스턴스를 파괴하기까지의 기본 수명(초)입니다.</summary>
+    private const float DefaultOneShotLifetime = 2f;
+
+    private const float DefaultPunchDuration = 0.3f;
+    private const int PunchVibrato = 6;
+    private const float PunchElasticity = 0.5f;
+
+    /// <summary>1회성 연출 프리팹을 스폰하고, 파티클 수명이 끝나면 자동으로 파괴합니다.</summary>
+    /// <param name="prefab">스폰할 프리팹 (null이면 무시)</param>
+    /// <param name="worldPos">스폰 위치(월드)</param>
+    /// <param name="parent">부모로 붙일 Transform (null이면 부모 없음)</param>
+    /// <returns>생성된 인스턴스 (prefab이 null이면 null)</returns>
+    public static GameObject SpawnOneShot(GameObject prefab, Vector3 worldPos, Transform parent = null)
+    {
+        if (prefab == null) return null;
+
+        GameObject instance = Object.Instantiate(prefab, worldPos, Quaternion.identity, parent);
+        float lifetime = CalculateLifetime(instance);
+        Object.Destroy(instance, lifetime);
+        return instance;
+    }
+
+    /// <summary>지속(루프) 연출 프리팹을 스폰합니다. 호출측이 반환된 인스턴스를 보관하고 직접 파괴해야 합니다.</summary>
+    /// <param name="prefab">스폰할 프리팹 (null이면 무시)</param>
+    /// <param name="worldPos">스폰 위치(월드)</param>
+    /// <param name="parent">부모로 붙일 Transform. 부모가 파괴되면 함께 정리됩니다.</param>
+    /// <returns>생성된 인스턴스 (prefab이 null이면 null)</returns>
+    public static GameObject SpawnLoop(GameObject prefab, Vector3 worldPos, Transform parent = null)
+    {
+        if (prefab == null) return null;
+        return Object.Instantiate(prefab, worldPos, Quaternion.identity, parent);
+    }
+
+    /// <summary>대상 Transform에 공통 펀치 스케일 트윈을 재생합니다. 위치(DOMove)와 독립적입니다.</summary>
+    /// <param name="target">펀치할 Transform (null이거나 strength가 0 이하면 무시)</param>
+    /// <param name="strength">펀치 세기(스케일 변화량)</param>
+    /// <param name="duration">트윈 진행 시간(초). 0 이하면 기본값 사용</param>
+    public static void PlayPunch(Transform target, float strength, float duration = DefaultPunchDuration)
+    {
+        if (target == null || strength <= 0f) return;
+        float dur = duration > 0f ? duration : DefaultPunchDuration;
+        target.DOPunchScale(Vector3.one * strength, dur, PunchVibrato, PunchElasticity);
+    }
+
+    /// <summary>인스턴스의 파티클 시스템들로부터 자동 파괴까지의 수명을 계산합니다.</summary>
+    private static float CalculateLifetime(GameObject instance)
+    {
+        ParticleSystem[] systems = instance.GetComponentsInChildren<ParticleSystem>(true);
+        if (systems == null || systems.Length == 0)
+            return DefaultOneShotLifetime;
+
+        float maxLifetime = 0f;
+        foreach (ParticleSystem ps in systems)
+        {
+            ParticleSystem.MainModule main = ps.main;
+            float duration = main.duration + main.startLifetime.constantMax;
+            if (duration > maxLifetime)
+                maxLifetime = duration;
+        }
+
+        return maxLifetime > 0f ? maxLifetime : DefaultOneShotLifetime;
+    }
+}

--- a/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs
@@ -62,7 +62,7 @@ public static class VFXSpawner
         foreach (ParticleSystem ps in systems)
         {
             ParticleSystem.MainModule main = ps.main;
-            float duration = main.duration + main.startLifetime.constantMax;
+            float duration = main.startDelay.constantMax + main.duration + main.startLifetime.constantMax;
             if (duration > maxLifetime)
                 maxLifetime = duration;
         }

--- a/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs.meta
+++ b/ChaosChess_v2/Assets/Script/Card/Effector/VFXSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18dd86e355da57347be75d69ce236b60

--- a/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ArenaCard.asset
@@ -14,9 +14,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CardName: "\uD22C\uAE30\uC7A5"
   CardImage: {fileID: -1063908585, guid: 4ab84a4b08c40404dbc95506084f3966, type: 3}
-  CardDescription: "\uB0B4 \uAE30\uBB3C \uC804\uCCB4\uC640 \uC0C1\uB300 \uAE30\uBB3C <color=#FFD700>4\uAE30</color>\uAC00 <color=#4499FF>\uD22C\uAE30\uC7A5</color>\uC73C\uB85C \uC774\uB3D9\uD569\uB2C8\uB2E4."
+  CardDescription: "\uB0B4 \uAE30\uBB3C \uC804\uCCB4\uC640 \uC0C1\uB300 \uAE30\uBB3C
+    <color=#FFD700>4\uAE30</color>\uAC00 <color=#4499FF>\uD22C\uAE30\uC7A5</color>\uC73C\uB85C
+    \uC774\uB3D9\uD569\uB2C8\uB2E4."
   Type: 2
   CardTier: 4
+  VFX:
+    ApplyVFXPrefab: {fileID: 0}
+    LoopVFXPrefab: {fileID: 0}
+    HookVFXPrefab: {fileID: 0}
+    RevertVFXPrefab: {fileID: 0}
+    PlayApplyAnim: 1
+    PlayHookAnim: 1
+    AnimStrength: 0.2
   PieceType: -1
   PieceTargetColor: 0
   PieceLimitTurn: 8
@@ -25,13 +35,17 @@ MonoBehaviour:
   MaintainTurn: 0
   NeedEffectTileBase: 0
   EffectTileBase: {fileID: 0}
+  UseMultipleEffectTileBases: 0
+  EffectTileBases: []
+  EffectTileAnimationMode: 0
+  EffectTileFrameInterval: 0.2
+  EffectTileAnimationFrames: []
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
-  ShowStatusCard: 0
   StatusDisplayType: 2
   NeedAdditionalDescription: 1
   DescriptionType: 1
@@ -39,4 +53,10 @@ MonoBehaviour:
   PieceDescImage: {fileID: 0}
   MovementImage: {fileID: 0}
   PieceDescContent: 
-  AdditionalDescriptionContent: "<color=#FFD700>8\uD134</color>\uAC04 \uC77C\uBC18 \uCCB4\uC2A4 \uB8F0\uB85C \uBBF8\uB2C8 \uAC8C\uC784\uC744 \uC9C4\uD589\uD569\uB2C8\uB2E4.\n\n<color=#00CC44>\uCCB4\uD06C\uBA54\uC774\uD2B8 \uB2EC\uC131 \u2192 \uC989\uC2DC \uC2B9\uB9AC</color>\n\uC0C1\uB300 \uAE30\uBB3C 3\uAE30(\uD0B9 \uC81C\uC678) \uD3EC\uD68D \u2192 \uBA54\uC778 \uAC8C\uC784 \uBCF5\uADC0 \uD6C4 <color=#00CC44>\uD574\uB2F9 \uAE30\uBB3C \uC81C\uAC70</color>\n<color=#FFD700>8\uD134</color> \uC885\uB8CC \u2192 \uAE30\uBB3C \uBCF5\uC6D0 \uD6C4 \uBA54\uC778 \uAC8C\uC784 \uBCF5\uADC0"
+  AdditionalDescriptionContent: "<color=#FFD700>8\uD134</color>\uAC04 \uC77C\uBC18
+    \uCCB4\uC2A4 \uB8F0\uB85C \uBBF8\uB2C8 \uAC8C\uC784\uC744 \uC9C4\uD589\uD569\uB2C8\uB2E4.\n\n<color=#00CC44>\uCCB4\uD06C\uBA54\uC774\uD2B8
+    \uB2EC\uC131 \u2192 \uC989\uC2DC \uC2B9\uB9AC</color>\n\uC0C1\uB300 \uAE30\uBB3C
+    3\uAE30(\uD0B9 \uC81C\uC678) \uD3EC\uD68D \u2192 \uBA54\uC778 \uAC8C\uC784 \uBCF5\uADC0
+    \uD6C4 <color=#00CC44>\uD574\uB2F9 \uAE30\uBB3C \uC81C\uAC70</color>\n<color=#FFD700>8\uD134</color>
+    \uC885\uB8CC \u2192 \uAE30\uBB3C \uBCF5\uC6D0 \uD6C4 \uBA54\uC778 \uAC8C\uC784
+    \uBCF5\uADC0"

--- a/ChaosChess_v2/Assets/Script/Card/SO/GiantCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/GiantCard.asset
@@ -14,9 +14,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CardName: "\uAC70\uB300\uD654"
   CardImage: {fileID: -2116945493, guid: 4ab84a4b08c40404dbc95506084f3966, type: 3}
-  CardDescription: "\uC120\uD0DD\uD55C \uAE30\uBB3C\uC5D0\uAC8C <color=#4499FF>\uAC70\uB300\uD654</color>\uB97C \uBD80\uC5EC\uD569\uB2C8\uB2E4."
+  CardDescription: "\uC120\uD0DD\uD55C \uAE30\uBB3C\uC5D0\uAC8C <color=#4499FF>\uAC70\uB300\uD654</color>\uB97C
+    \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   Type: 0
   CardTier: 2
+  VFX:
+    ApplyVFXPrefab: {fileID: 0}
+    LoopVFXPrefab: {fileID: 0}
+    HookVFXPrefab: {fileID: 0}
+    RevertVFXPrefab: {fileID: 0}
+    PlayApplyAnim: 1
+    PlayHookAnim: 1
+    AnimStrength: 0.3
+    AnimDuration: 0.2
   PieceType: 7
   PieceTargetColor: 0
   PieceLimitTurn: -1
@@ -25,13 +35,17 @@ MonoBehaviour:
   MaintainTurn: 0
   NeedEffectTileBase: 0
   EffectTileBase: {fileID: 0}
+  UseMultipleEffectTileBases: 0
+  EffectTileBases: []
+  EffectTileAnimationMode: 0
+  EffectTileFrameInterval: 0.2
+  EffectTileAnimationFrames: []
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
-  ShowStatusCard: 0
   StatusDisplayType: 0
   NeedAdditionalDescription: 1
   DescriptionType: 1
@@ -39,4 +53,6 @@ MonoBehaviour:
   PieceDescImage: {fileID: 0}
   MovementImage: {fileID: 0}
   PieceDescContent: 
-  AdditionalDescriptionContent: "\uC774\uB3D9\uD560 \uB54C\uB9C8\uB2E4 \uB3C4\uCC29 \uC704\uCE58 <color=#FFD700>\uBC18\uACBD 1\uCE78</color> \uB0B4 \uAE30\uBB3C\uB4E4\uC744 <color=#FFD700>1\uD134</color>\uAC04 <color=#FF4444>\uBB34\uB825\uD654</color>\uD569\uB2C8\uB2E4."
+  AdditionalDescriptionContent: "\uC774\uB3D9\uD560 \uB54C\uB9C8\uB2E4 \uB3C4\uCC29
+    \uC704\uCE58 <color=#FFD700>\uBC18\uACBD 1\uCE78</color> \uB0B4 \uAE30\uBB3C\uB4E4\uC744
+    <color=#FFD700>1\uD134</color>\uAC04 <color=#FF4444>\uBB34\uB825\uD654</color>\uD569\uB2C8\uB2E4."

--- a/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/LimitlessCard.asset
@@ -14,28 +14,47 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CardName: "\uBB34\uD558\uD55C"
   CardImage: {fileID: 2063513820, guid: 4ab84a4b08c40404dbc95506084f3966, type: 3}
-  CardDescription: "\uC120\uD0DD\uD55C \uAE30\uBB3C \uC8FC\uC704\uC5D0 <color=#4499FF>\uBD09\uC778 \uAD6C\uC5ED</color>\uC744 \uC124\uC815\uD569\uB2C8\uB2E4."
+  CardDescription: "\uC120\uD0DD\uD55C \uAE30\uBB3C \uC8FC\uC704\uC5D0 <color=#4499FF>\uBD09\uC778
+    \uAD6C\uC5ED</color>\uC744 \uC124\uC815\uD569\uB2C8\uB2E4."
   Type: 0
   CardTier: 1
+  VFX:
+    ApplyVFXPrefab: {fileID: 0}
+    LoopVFXPrefab: {fileID: 0}
+    HookVFXPrefab: {fileID: 0}
+    RevertVFXPrefab: {fileID: 0}
+    PlayApplyAnim: 1
+    PlayHookAnim: 1
+    AnimStrength: 0.2
+    AnimDuration: 0.3
   PieceType: -1
   PieceTargetColor: 0
   PieceLimitTurn: -1
   RequiredPieceCount: 1
   TileCount: 0
   MaintainTurn: 0
-  NeedEffectTileBase: 0
-  EffectTileBase: {fileID: 0}
+  NeedEffectTileBase: 1
+  EffectTileBase: {fileID: 11400000, guid: 2ea4e41bf1020104aadf5e26276394e6, type: 2}
+  UseMultipleEffectTileBases: 0
+  EffectTileBases: []
+  EffectTileAnimationMode: 0
+  EffectTileFrameInterval: 0.2
+  EffectTileAnimationFrames: []
   RestrictTiles: 0
   BlockedTiles: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
   NeedTargetColor: 0
   GlobalTargetColor: 0
   HasLimit: 0
   LimitTurn: 0
-  ShowStatusCard: 0
+  StatusDisplayType: 0
   NeedAdditionalDescription: 1
   DescriptionType: 1
   AdditionalDescriptionTitle: "\uBD09\uC778 \uAD6C\uC5ED"
   PieceDescImage: {fileID: 0}
   MovementImage: {fileID: 0}
   PieceDescContent: 
-  AdditionalDescriptionContent: "\uD574\uB2F9 \uAE30\uBB3C\uC740 <color=#FF4444>\uC774\uB3D9 \uBD88\uAC00</color>. \uBC18\uACBD <color=#FFD700>1\uCE78</color> \uB0B4\uB85C \uC5B4\uB5A0\uD55C \uAE30\uBB3C\uB3C4 \uC811\uADFC\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4. \uC9C4\uC785 \uC2DC\uB3C4 \uC2DC \uC218\uAC00 \uCDE8\uC18C\uB418\uBA70 \uD6A8\uACFC\uAC00 \uD574\uC81C\uB429\uB2C8\uB2E4."
+  AdditionalDescriptionContent: "\uD574\uB2F9 \uAE30\uBB3C\uC740 <color=#FF4444>\uC774\uB3D9
+    \uBD88\uAC00</color>. \uBC18\uACBD <color=#FFD700>1\uCE78</color> \uB0B4\uB85C
+    \uC5B4\uB5A0\uD55C \uAE30\uBB3C\uB3C4 \uC811\uADFC\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
+    \uC9C4\uC785 \uC2DC\uB3C4 \uC2DC \uC218\uAC00 \uCDE8\uC18C\uB418\uBA70 \uD6A8\uACFC\uAC00
+    \uD574\uC81C\uB429\uB2C8\uB2E4."

--- a/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/LimitlessCard.cs
@@ -146,11 +146,13 @@ public class LimitlessTileEffector : TileEffector, IArenaPersistentEffect
 
     protected override void OnApply()
     {
+        ShowTileEffect();
         BoardManager.Instance.RegisterTileEffector(tilePos, this);
     }
 
     protected override void OnRevert()
     {
+        ClearTileEffect();
         BoardManager.Instance.UnregisterTileEffector(tilePos, this);
         Destroy(gameObject);
     }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardManager.cs
@@ -113,6 +113,9 @@ public class BoardManager : MonoBehaviour
     /// <summary>직전 수가 바뀔 때 (from, to)를 통지합니다. 하이라이트 UI가 구독합니다.</summary>
     public event System.Action<Vector3Int, Vector3Int> OnLastMoveChanged;
 
+    /// <summary>효과로 차단되어 취소된 수의 시도 (from, to)를 통지합니다. 하이라이트 UI가 구독합니다.</summary>
+    public event System.Action<Vector3Int, Vector3Int> OnMoveBlocked;
+
     [SerializeField] private string FEN;
     private List<Piece> Pieces = new List<Piece>();
     private Piece[,] board = new Piece[8, 8];
@@ -382,7 +385,10 @@ public class BoardManager : MonoBehaviour
         Vector3Int from = piece.Pos;
 
         if (!CanMoveToTile(piece, from, target))
+        {
+            OnMoveBlocked?.Invoke(from, target); // 시도한 from→to를 하이라이트로 표시
             return true; // 기물 이동을 안하고 턴을 넘김
+        }
 
         Vector3Int prevEP = enPassantPos;
         enPassantPos = new Vector3Int(-1, -1, -1);

--- a/ChaosChess_v2/Assets/Script/ChessSystem/BoardUI.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/BoardUI.cs
@@ -13,6 +13,8 @@ public class BoardUI : MonoBehaviour
     [Header("직전 수 하이라이트 (전용 레이어)")]
     [SerializeField] private Tilemap LastMoveBoard;
     [SerializeField] private TileBase LastMoveTile;
+    [Tooltip("효과로 차단되어 취소된 수의 from/to에 표시할 타일 (구분 색). 비우면 LastMoveTile 사용)")]
+    [SerializeField] private TileBase BlockedMoveTile;
 
     private Vector3Int prvMouseCellPos;
     private List<Vector3Int> drawnMoveTilePositions = new List<Vector3Int>();
@@ -89,16 +91,26 @@ public class BoardUI : MonoBehaviour
     public void DrawLastMove(Vector3Int from, Vector3Int to)
     {
         ClearLastMove();
-        StampLastMove(from);
-        StampLastMove(to);
+        StampMove(from, LastMoveTile);
+        StampMove(to, LastMoveTile);
     }
 
-    private void StampLastMove(Vector3Int pos)
+    /// <summary>효과로 차단되어 취소된 수의 시도 출발/도착 칸을 하이라이트합니다.
+    /// 직전 수 레이어를 공유하므로 다음 수가 그려질 때 자연히 덮어써집니다.</summary>
+    public void DrawBlockedMove(Vector3Int from, Vector3Int to)
     {
-        if (LastMoveBoard == null || LastMoveTile == null) return;
+        TileBase tile = BlockedMoveTile != null ? BlockedMoveTile : LastMoveTile;
+        ClearLastMove();
+        StampMove(from, tile);
+        StampMove(to, tile);
+    }
+
+    private void StampMove(Vector3Int pos, TileBase tile)
+    {
+        if (LastMoveBoard == null || tile == null) return;
         if (pos.x < 0 || pos.y < 0) return;
 
-        LastMoveBoard.SetTile(pos, LastMoveTile);
+        LastMoveBoard.SetTile(pos, tile);
         LastMoveBoard.SetTileFlags(pos, TileFlags.None);
         lastMoveTilePositions.Add(pos);
     }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -114,6 +114,9 @@ public class GameManager : MonoBehaviour
         {
             BoardManager.Instance.OnLastMoveChanged -= boardUI.DrawLastMove;
             BoardManager.Instance.OnLastMoveChanged += boardUI.DrawLastMove;
+
+            BoardManager.Instance.OnMoveBlocked -= boardUI.DrawBlockedMove;
+            BoardManager.Instance.OnMoveBlocked += boardUI.DrawBlockedMove;
         }
 
         OnTimeReversalRequired -= HandleTimeReversal;

--- a/ChaosChess_v2/Assets/Script/UI/Animation/SplashPanelAnim.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Animation/SplashPanelAnim.cs
@@ -1,0 +1,43 @@
+﻿using DG.Tweening;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SplashPanelAnim : MonoBehaviour
+{
+    [SerializeField] private Image logoImage;
+    [SerializeField] private CanvasGroup canvasGroup;
+    [SerializeField] private float fadeDuration = 0.5f;
+    [SerializeField] private float splashImageDuration = 0.5f;
+    [SerializeField] private float canvasFadeDuration = 0.5f;
+
+    private void Start()
+    {
+        // 초기 상태 설정
+        logoImage.color = Color.clear;
+        canvasGroup.alpha = 1f;
+        // 스플래시 동안 뒤쪽 UI로 터치/클릭이 새지 않도록 입력을 막는다
+        canvasGroup.blocksRaycasts = true;
+        canvasGroup.interactable = true;
+
+        Sequence seq = DOTween.Sequence();
+
+        // 1) 로고 페이드 인
+        seq.Append(logoImage.DOColor(Color.white, fadeDuration));
+        // 2) 잠깐 유지
+        seq.AppendInterval(splashImageDuration);
+        // 3) 로고 페이드 아웃
+        seq.Append(logoImage.DOColor(Color.clear, fadeDuration));
+        // 4) 캔버스 전체 페이드 아웃
+        seq.Append(canvasGroup.DOFade(0f, canvasFadeDuration));
+        // 5) 끝나면 입력 차단을 풀고 비활성화
+        seq.AppendCallback(() =>
+        {
+            canvasGroup.blocksRaycasts = false;
+            canvasGroup.interactable = false;
+            canvasGroup.gameObject.SetActive(false);
+        });
+
+        seq.Play();
+    }
+}

--- a/ChaosChess_v2/Assets/Script/UI/Animation/SplashPanelAnim.cs.meta
+++ b/ChaosChess_v2/Assets/Script/UI/Animation/SplashPanelAnim.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74ff0678fe17a2c448efb9c394d5eada

--- a/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
+++ b/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
@@ -18,6 +18,7 @@ public class ButtonCanvas : ButtonParent
     [SerializeField] private List<BasicUIAnimation> animationButtons;
     [SerializeField] private UnityEvent OnCanvasEnabled;
     [SerializeField] private UnityEvent OnCanvasDisabled;
+    [SerializeField] private UnityEvent OnFadeComplete;
 
     private CanvasGroup canvasGroup;
     private ScrollRect scrollRect;
@@ -25,8 +26,7 @@ public class ButtonCanvas : ButtonParent
 
     protected virtual void Awake()
     {
-        canvasGroup = GetComponent<CanvasGroup>();
-        // Debug.Log($"{gameObject.name}에 있는 캔버스 그룹 오브젝트: {canvasGroup.gameObject.name}");
+        canvasGroup = GetComponent<CanvasGroup>();;
         canvas = GetComponent<Canvas>();
         scrollRect = GetComponentInChildren<ScrollRect>();
     }
@@ -58,7 +58,7 @@ public class ButtonCanvas : ButtonParent
 
     public void FadeOut()
     {
-        canvasGroup.DOFade(1f, fadeDuration);
+        canvasGroup.DOFade(1f, fadeDuration).OnComplete(() => OnFadeComplete?.Invoke());
         int animIndex = 0;
         for (int i = 0; i < animationButtons.Count; i++)
         {
@@ -69,7 +69,6 @@ public class ButtonCanvas : ButtonParent
     }
     public void FadeIn()
     {
-        // Debug.Log($"{gameObject.name} 캔버스 그룹 인스턴스 아이디: {canvasGroup.GetInstanceID()} ");
         canvasGroup.DOFade(0f, fadeDuration)
             .OnComplete(() =>
             {

--- a/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
+++ b/ChaosChess_v2/Assets/Script/UI/ButtonCanvas.cs
@@ -26,7 +26,7 @@ public class ButtonCanvas : ButtonParent
 
     protected virtual void Awake()
     {
-        canvasGroup = GetComponent<CanvasGroup>();;
+        canvasGroup = GetComponent<CanvasGroup>();
         canvas = GetComponent<Canvas>();
         scrollRect = GetComponentInChildren<ScrollRect>();
     }

--- a/ChaosChess_v2/Assets/Tilemap/moveCancelBoard.asset
+++ b/ChaosChess_v2/Assets/Tilemap/moveCancelBoard.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: moveCancelBoard
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 5407276388446273561, guid: 8005fd67b092a404785cc915b51a0a17, type: 3}
+  m_Color: {r: 1, g: 0, b: 0.10529566, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/ChaosChess_v2/Assets/Tilemap/moveCancelBoard.asset.meta
+++ b/ChaosChess_v2/Assets/Tilemap/moveCancelBoard.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da4a65c4809a7c0408dfec003b0e5190
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChaosChess_v2/ProjectSettings/ProjectSettings.asset
+++ b/ChaosChess_v2/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0, g: 0, b: 0, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 0
@@ -39,9 +39,7 @@ PlayerSettings:
     y: 0
     width: 1
     height: 1
-  m_SplashScreenLogos:
-  - logo: {fileID: 21300000, guid: 82185ee7a978fe947881aa44bf718c04, type: 3}
-    duration: 2
+  m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1920
@@ -144,7 +142,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 1.0
+  bundleVersion: 0.1.1+8.g1904e37.dirty
   preloadedAssets:
   - {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   - {fileID: 11400000, guid: c48a5aa91931762448f1651542ab722e, type: 2}


### PR DESCRIPTION
@
# 개요
카드 효과에 시각 효과(VFX)를 입히는 프레임워크를 추가하고, 보드/카드 관련 UI 표현과 스플래시 화면을 개선합니다.

# 내용
## 카드 효과 VFX 프레임워크
- 파티클·DOTween 기반 카드 효과 VFX 프레임워크 추가 (`VFXSpawner`, `Effector` 확장)
- `CardDataSO`에 VFX 설정 필드 추가 및 전용 에디터(`CardDataSOEditor`) 추가
- `Effector.md` 문서에 VFX 사용 규약 보강

## 보드 / 카드 UI 표현
- 무한 효과 범위 타일 표시 (`LimitlessCard`)
- 차단된 수의 from→to 하이라이트 표시 (`BoardUI`, `moveCancelBoard` 타일맵)

## 스플래시 / 빌드
- 커스텀 스플래시 화면 및 애니메이션(`SplashPanelAnim`) 추가
- Unity 기본 스플래시 비활성화 및 버전 갱신
- 머티리얼·렌더 에셋 변경 반영

# 기타 사항
없음
@