### PR TITLE
[Feature] 카드 지급 턴 UI 구현

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -8304,7 +8304,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 1
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: -344459325
   m_SortingOrder: 0
@@ -8325,6 +8325,7 @@ RectTransform:
   - {fileID: 232779361}
   - {fileID: 1750176424}
   - {fileID: 122585166}
+  - {fileID: 3200000301}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -21380,6 +21381,81 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &2044707026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2044707027}
+  - component: {fileID: 2044707029}
+  - component: {fileID: 2044707028}
+  m_Layer: 5
+  m_Name: Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2044707027
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044707026}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3200000301}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2044707028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044707026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5da278b4ad962ea49b52e728dab946b4, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
+--- !u!222 &2044707029
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2044707026}
+  m_CullTransparentMesh: 1
 --- !u!1 &2046218171
 GameObject:
   m_ObjectHideFlags: 0
@@ -22532,6 +22608,235 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
+--- !u!1 &3200000300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3200000301}
+  - component: {fileID: 3200000302}
+  - component: {fileID: 3200000303}
+  - component: {fileID: 3200000304}
+  m_Layer: 5
+  m_Name: CardGrantStatus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3200000301
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000300}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3200000341}
+  - {fileID: 2044707027}
+  m_Father: {fileID: 1036672678}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 30, y: 1050}
+  m_SizeDelta: {x: 500, y: 200}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &3200000302
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000300}
+  m_CullTransparentMesh: 1
+--- !u!114 &3200000303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 16828e59bfb80334199b43bfd9f2d6c8, type: 2}
+  m_Color: {r: 0.08235294, g: 0.08235294, b: 0.08235294, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1053917808771471321, guid: 01012e4e38ad1624c9d7452dc99af337, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3200000304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b8e5af207de4bc99a41c6c46d258fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  statusRoot: {fileID: 3200000301}
+  labelText: {fileID: 3200000343}
+--- !u!1 &3200000340
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3200000341}
+  - component: {fileID: 3200000342}
+  - component: {fileID: 3200000343}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3200000341
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000340}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3200000301}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -48, y: -36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3200000342
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000340}
+  m_CullTransparentMesh: 1
+--- !u!114 &3200000343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000340}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "<size=84><color=#FFE633>5\uD134</color></size> \uD6C4 \uC9C0\uAE09"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
+  m_sharedMaterial: {fileID: 2683479388609967759, guid: e5e0943f465818e4f86c27efc410addc, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &2598052484459980064
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/Card/CardRandomizer.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardRandomizer.cs
@@ -10,6 +10,7 @@ public class CardRandomizer : MonoBehaviour
 
     private int currentCardCnt = 0;
     public int CurrentCardCnt => currentCardCnt;
+    public event System.Action<int> OnCardCountChanged;
 
     private Dictionary<GameObject, GameObject> _activeCards = new();
 
@@ -24,7 +25,7 @@ public class CardRandomizer : MonoBehaviour
     /// 지정된 카드 풀에서 현재 활성 카드와
     /// 중복되지 않는 랜덤 카드를 생성합니다.
     /// </summary>
-    public void GenerateCard(List<GameObject> pool, int count = 1)
+    public int GenerateCard(List<GameObject> pool, int count = 1)
     {
         List<GameObject> randomCards =
             cardRandomizerManager.GetRandomCardsFromPool(
@@ -34,12 +35,14 @@ public class CardRandomizer : MonoBehaviour
             );
 
         if (randomCards.Count == 0)
-            return;
+            return 0;
 
         currentCardCnt += randomCards.Count;
+        OnCardCountChanged?.Invoke(currentCardCnt);
 
         // 코루틴으로 카드 딜레이 스폰 기능 부여
         StartCoroutine(SpawnCard(randomCards, spawnDelay));
+        return randomCards.Count;
     }
 
     private IEnumerator SpawnCard(List<GameObject> list, float delay)
@@ -62,5 +65,6 @@ public class CardRandomizer : MonoBehaviour
         currentCardCnt--;
 
         _activeCards.Remove(card);
+        OnCardCountChanged?.Invoke(currentCardCnt);
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -47,6 +47,8 @@ public class GameManager : MonoBehaviour
 
     /// <summary>플레이어 턴이 시작되고 CanMovePos가 유효해진 직후 발행됩니다.</summary>
     public event Action OnPlayerTurnStarted;
+    /// <summary>카드 지급 주기 카운트의 일시정지 상태가 바뀔 때 발행됩니다.</summary>
+    public event Action OnCardIntervalPauseChanged;
     /// <summary>매 턴(플레이어·AI 모두) 종료 직후 발행됩니다. Effector 지속 턴 카운트다운에 사용됩니다.</summary>
     public event Action OnTurnChanged;
     /// <summary>반 턴 종료 직후 발행됩니다.</summary>
@@ -449,12 +451,14 @@ public class GameManager : MonoBehaviour
     public void PushCardIntervalPause()
     {
         cardIntervalPauseCount++;
+        OnCardIntervalPauseChanged?.Invoke();
     }
 
     /// <summary>카드 지급 주기 카운트 일시 정지를 해제합니다.</summary>
     public void PopCardIntervalPause()
     {
         cardIntervalPauseCount = Mathf.Max(0, cardIntervalPauseCount - 1);
+        OnCardIntervalPauseChanged?.Invoke();
     }
 
     // MoveSelected 안에서 플레이어 수 적용 후:
@@ -776,6 +780,7 @@ public class GameManager : MonoBehaviour
     private void ResetActions()
     {
         OnPlayerTurnStarted = null;
+        OnCardIntervalPauseChanged = null;
         OnTurnChanged = null;
         OnHalfTurnChanged = null;
         OnTimeReversalRequired = null;

--- a/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
@@ -24,6 +24,12 @@ public class Player : MonoBehaviour
 
     private void Start()
     {
+        if (cardRandomizer == null)
+        {
+            Debug.LogError($"{nameof(Player)} requires a {nameof(CardRandomizer)} reference.", this);
+            return;
+        }
+
         GameManager.Instance.OnPlayerTurnStarted += HandlePlayerTurnStarted;
         GameManager.Instance.OnCardIntervalPauseChanged += HandleCardIntervalPauseChanged;
         cardRandomizer.OnCardCountChanged += HandleCardCountChanged;
@@ -35,8 +41,7 @@ public class Player : MonoBehaviour
         _buffs = new List<BuffPick>(PlayerState.Instance.Buffs);
 
         ExecuteBuffs();
-        int currentCardCnt = cardRandomizer.CurrentCardCnt;
-        int spawnCount = _maxCardCount - currentCardCnt;
+        int spawnCount = _maxCardCount - CurrentCardCount;
         if (spawnCount > 0)
             cardRandomizer.GenerateCard(_cardPool, spawnCount);
 
@@ -73,7 +78,7 @@ public class Player : MonoBehaviour
         }
 
         _playerTurnCount++;
-        if (_playerTurnCount < _cardInterval || cardRandomizer.CurrentCardCnt >= _maxCardCount)
+        if (_playerTurnCount < _cardInterval || IsCardHandFull)
         {
             NotifyCardGrantStateChanged();
             return;

--- a/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
@@ -13,7 +13,7 @@ public class Player : MonoBehaviour
     private int _playerTurnCount = 0;
 
     public bool IsCardGrantInitialized { get; private set; }
-    public int RemainingTurnsUntilCardGrant => Mathf.Max(0, _cardInterval - _playerTurnCount);
+    public int RemainingTurnsUntilCardGrant => Mathf.Max(1, _cardInterval - _playerTurnCount);
     public bool IsCardHandFull => CurrentCardCount >= _maxCardCount;
     public bool IsCardGrantPaused => GameManager.Instance != null && GameManager.Instance.IsCardIntervalPaused;
 

--- a/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
@@ -14,7 +14,6 @@ public class Player : MonoBehaviour
 
     public bool IsCardGrantInitialized { get; private set; }
     public int RemainingTurnsUntilCardGrant => Mathf.Max(0, _cardInterval - _playerTurnCount);
-    public bool IsCardGrantReady => _playerTurnCount >= _cardInterval;
     public bool IsCardHandFull => CurrentCardCount >= _maxCardCount;
     public bool IsCardGrantPaused => GameManager.Instance != null && GameManager.Instance.IsCardIntervalPaused;
 

--- a/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
+++ b/ChaosChess_v2/Assets/Script/GameCycle/Player.cs
@@ -12,9 +12,22 @@ public class Player : MonoBehaviour
     private int _maxCardCount;
     private int _playerTurnCount = 0;
 
+    public bool IsCardGrantInitialized { get; private set; }
+    public int RemainingTurnsUntilCardGrant => Mathf.Max(0, _cardInterval - _playerTurnCount);
+    public bool IsCardGrantReady => _playerTurnCount >= _cardInterval;
+    public bool IsCardHandFull => CurrentCardCount >= _maxCardCount;
+    public bool IsCardGrantPaused => GameManager.Instance != null && GameManager.Instance.IsCardIntervalPaused;
+
+    private int CurrentCardCount => cardRandomizer != null ? cardRandomizer.CurrentCardCnt : 0;
+
+    public event System.Action OnCardGrantStateChanged;
+    public event System.Action OnCardGranted;
+
     private void Start()
     {
         GameManager.Instance.OnPlayerTurnStarted += HandlePlayerTurnStarted;
+        GameManager.Instance.OnCardIntervalPauseChanged += HandleCardIntervalPauseChanged;
+        cardRandomizer.OnCardCountChanged += HandleCardCountChanged;
 
         _cardInterval = PlayerState.Instance.DefaultCardInterval;
         _maxCardCount = PlayerState.Instance.DefaultMaxCardCount;
@@ -27,6 +40,9 @@ public class Player : MonoBehaviour
         int spawnCount = _maxCardCount - currentCardCnt;
         if (spawnCount > 0)
             cardRandomizer.GenerateCard(_cardPool, spawnCount);
+
+        IsCardGrantInitialized = true;
+        NotifyCardGrantStateChanged();
     }
 
     private void ExecuteBuffs()
@@ -40,29 +56,63 @@ public class Player : MonoBehaviour
     private void OnDestroy()
     {
         if (GameManager.Instance != null)
+        {
             GameManager.Instance.OnPlayerTurnStarted -= HandlePlayerTurnStarted;
+            GameManager.Instance.OnCardIntervalPauseChanged -= HandleCardIntervalPauseChanged;
+        }
+
+        if (cardRandomizer != null)
+            cardRandomizer.OnCardCountChanged -= HandleCardCountChanged;
     }
 
     private void HandlePlayerTurnStarted()
     {
-        if (GameManager.Instance.IsCardIntervalPaused) return;
+        if (GameManager.Instance.IsCardIntervalPaused)
+        {
+            NotifyCardGrantStateChanged();
+            return;
+        }
 
         _playerTurnCount++;
-        if (_playerTurnCount < _cardInterval || cardRandomizer.CurrentCardCnt >= _maxCardCount) return;
-        _playerTurnCount = 0;
+        if (_playerTurnCount < _cardInterval || cardRandomizer.CurrentCardCnt >= _maxCardCount)
+        {
+            NotifyCardGrantStateChanged();
+            return;
+        }
 
-        cardRandomizer.GenerateCard(_cardPool);
+        int generatedCount = cardRandomizer.GenerateCard(_cardPool);
+        if (generatedCount <= 0)
+        {
+            NotifyCardGrantStateChanged();
+            return;
+        }
+
+        _playerTurnCount = 0;
+        NotifyCardGrantStateChanged();
+        OnCardGranted?.Invoke();
     }
 
     /// <summary>카드 지급 주기를 delta만큼 조정합니다. 최소값은 1입니다.</summary>
     public void ModifyCardInterval(int delta)
     {
         _cardInterval = Mathf.Max(1, _cardInterval + delta);
+        NotifyCardGrantStateChanged();
     }
 
     /// <summary>보유할 수 있는 카드 개수를 delta만큼 조정합니다. 최소값은 1, 최대값은 PlayerState.Instance.DefaultMaxCardCount(4)입니다.</summary>
     public void ModifyMaxCardCount(int delta)
     {
         _maxCardCount = Mathf.Clamp(_maxCardCount + delta, 1, PlayerState.Instance.DefaultMaxCardCount);
+        NotifyCardGrantStateChanged();
+    }
+
+    private void HandleCardCountChanged(int _) => NotifyCardGrantStateChanged();
+
+    private void HandleCardIntervalPauseChanged() => NotifyCardGrantStateChanged();
+
+    private void NotifyCardGrantStateChanged()
+    {
+        if (IsCardGrantInitialized)
+            OnCardGrantStateChanged?.Invoke();
     }
 }

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
@@ -8,7 +8,7 @@ public class CardGrantStatusUI : MonoBehaviour
     private const float GrantMessageDuration = 0.8f;
     private const int EmphasisSize = 84;
     private const string WaitingHex = "#FFE633";
-    private const string ReadyHex = "#75D6FF";
+    private const string GrantedHex = "#75D6FF";
     private const string NoticeHex = "#FF9F43";
 
     [SerializeField] private RectTransform statusRoot;
@@ -75,12 +75,6 @@ public class CardGrantStatusUI : MonoBehaviour
             return;
         }
 
-        if (player.IsCardGrantReady)
-        {
-            SetStatus($"카드 {Emphasize("지급 가능", ReadyHex)}");
-            return;
-        }
-
         int remainingTurns = player.RemainingTurnsUntilCardGrant;
         SetStatus($"{Emphasize($"{remainingTurns}턴", WaitingHex)} 후 지급");
     }
@@ -90,7 +84,7 @@ public class CardGrantStatusUI : MonoBehaviour
         if (statusRoot == null || labelText == null) return;
 
         grantSequence?.Kill();
-        SetStatus($"카드 {Emphasize("지급!", ReadyHex)}");
+        SetStatus($"카드 {Emphasize("지급!", GrantedHex)}");
         statusRoot.localScale = Vector3.one;
 
         grantSequence = DOTween.Sequence()

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
@@ -38,11 +38,15 @@ public class CardGrantStatusUI : MonoBehaviour
 
     private IEnumerator BindPlayerWhenReady()
     {
-        while (player == null || !player.IsCardGrantInitialized)
+        while (player == null)
         {
             player = FindFirstObjectByType<Player>();
-            yield return null;
+            if (player == null)
+                yield return null;
         }
+
+        while (!player.IsCardGrantInitialized)
+            yield return null;
 
         player.OnCardGrantStateChanged += Refresh;
         player.OnCardGranted += PlayGrantedFeedback;
@@ -62,6 +66,8 @@ public class CardGrantStatusUI : MonoBehaviour
     private void Refresh()
     {
         if (player == null || labelText == null) return;
+
+        if (grantSequence != null && grantSequence.IsActive() && grantSequence.IsPlaying()) return;
 
         if (player.IsCardGrantPaused)
         {
@@ -91,7 +97,11 @@ public class CardGrantStatusUI : MonoBehaviour
             .Append(statusRoot.DOScale(1.08f, 0.12f))
             .Append(statusRoot.DOScale(1f, 0.12f))
             .AppendInterval(GrantMessageDuration)
-            .OnComplete(Refresh);
+            .OnComplete(() =>
+            {
+                grantSequence = null;
+                Refresh();
+            });
     }
 
     private void SetStatus(string text)

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using DG.Tweening;
+using TMPro;
+using UnityEngine;
+
+public class CardGrantStatusUI : MonoBehaviour
+{
+    private const float GrantMessageDuration = 0.8f;
+    private const int EmphasisSize = 84;
+    private const string WaitingHex = "#FFE633";
+    private const string ReadyHex = "#75D6FF";
+    private const string NoticeHex = "#FF9F43";
+
+    [SerializeField] private RectTransform statusRoot;
+    [SerializeField] private TMP_Text labelText;
+
+    private Player player;
+    private Sequence grantSequence;
+    private Coroutine bindCoroutine;
+
+    private void OnEnable()
+    {
+        bindCoroutine = StartCoroutine(BindPlayerWhenReady());
+    }
+
+    private void OnDisable()
+    {
+        if (bindCoroutine != null)
+        {
+            StopCoroutine(bindCoroutine);
+            bindCoroutine = null;
+        }
+
+        UnbindPlayer();
+        grantSequence?.Kill();
+        grantSequence = null;
+    }
+
+    private IEnumerator BindPlayerWhenReady()
+    {
+        while (player == null || !player.IsCardGrantInitialized)
+        {
+            player = FindFirstObjectByType<Player>();
+            yield return null;
+        }
+
+        player.OnCardGrantStateChanged += Refresh;
+        player.OnCardGranted += PlayGrantedFeedback;
+        bindCoroutine = null;
+        Refresh();
+    }
+
+    private void UnbindPlayer()
+    {
+        if (player == null) return;
+
+        player.OnCardGrantStateChanged -= Refresh;
+        player.OnCardGranted -= PlayGrantedFeedback;
+        player = null;
+    }
+
+    private void Refresh()
+    {
+        if (player == null || labelText == null) return;
+
+        if (player.IsCardGrantPaused)
+        {
+            SetStatus($"{Emphasize("대기", NoticeHex)} 중");
+            return;
+        }
+
+        if (player.IsCardHandFull)
+        {
+            SetStatus($"손패 {Emphasize("가득 참", NoticeHex)}");
+            return;
+        }
+
+        if (player.IsCardGrantReady)
+        {
+            SetStatus($"카드 {Emphasize("지급 가능", ReadyHex)}");
+            return;
+        }
+
+        int remainingTurns = player.RemainingTurnsUntilCardGrant;
+        SetStatus($"{Emphasize($"{remainingTurns}턴", WaitingHex)} 후 지급");
+    }
+
+    private void PlayGrantedFeedback()
+    {
+        if (statusRoot == null || labelText == null) return;
+
+        grantSequence?.Kill();
+        SetStatus($"카드 {Emphasize("지급!", ReadyHex)}");
+        statusRoot.localScale = Vector3.one;
+
+        grantSequence = DOTween.Sequence()
+            .Append(statusRoot.DOScale(1.08f, 0.12f))
+            .Append(statusRoot.DOScale(1f, 0.12f))
+            .AppendInterval(GrantMessageDuration)
+            .OnComplete(Refresh);
+    }
+
+    private void SetStatus(string text)
+    {
+        labelText.text = text;
+        labelText.color = Color.white;
+    }
+
+    private static string Emphasize(string text, string colorHex) =>
+        $"<size={EmphasisSize}><color={colorHex}>{text}</color></size>";
+}

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs
@@ -38,20 +38,26 @@ public class CardGrantStatusUI : MonoBehaviour
 
     private IEnumerator BindPlayerWhenReady()
     {
-        while (player == null)
+        while (true)
         {
-            player = FindFirstObjectByType<Player>();
-            if (player == null)
+            while (player == null)
+            {
+                player = FindFirstObjectByType<Player>();
                 yield return null;
+            }
+
+            while (player != null && !player.IsCardGrantInitialized)
+                yield return null;
+
+            if (player != null)
+            {
+                player.OnCardGrantStateChanged += Refresh;
+                player.OnCardGranted += PlayGrantedFeedback;
+                bindCoroutine = null;
+                Refresh();
+                yield break;
+            }
         }
-
-        while (!player.IsCardGrantInitialized)
-            yield return null;
-
-        player.OnCardGrantStateChanged += Refresh;
-        player.OnCardGranted += PlayGrantedFeedback;
-        bindCoroutine = null;
-        Refresh();
     }
 
     private void UnbindPlayer()

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs.meta
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardGrantStatusUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b8e5af207de4bc99a41c6c46d258fd7


### PR DESCRIPTION
## 개요

플레이어가 다음 카드를 언제 지급받는지 확인하기 어려웠던 문제를 개선합니다.  
메인 게임 화면에 카드 지급까지 남은 턴과 지급 상태를 표시하는 UI를 추가했습니다.
카드 수, 지급 주기 및 아레나 진행 여부에 따라 상태가 갱신됩니다.

## 작업 내용

- 카드 지급까지 남은 턴을 표시하는 UI 추가
- `5턴 후 지급` 형식으로 남은 턴 표시
- 남은 턴 숫자에 크기 및 색상 강조 적용
- 카드 지급 대기, 손패 가득 참 상태 표시
- 카드 지급 시 간단한 스케일 애니메이션 적용
- 카드 수, 지급 주기, 지급 일시정지 상태 변경 시 UI 즉시 갱신
- `MainGameScene`에 `CardGrantStatus` UI를 직접 배치

## 로직 변경

- `Player`에서 카드 지급 상태와 남은 턴 제공
- 카드 지급 및 상태 변경 이벤트 추가
- `CardRandomizer`에서 실제 생성된 카드 수 반환
- 카드 수 변경 이벤트 추가
- `GameManager`에서 카드 지급 주기 일시정지 변경 이벤트 제공
- 카드 생성에 실패한 경우 지급 주기 카운트를 초기화하지 않도록 처리

## 색상 처리

TMP 리치 텍스트에서 강조 범위에만 색상을 적용하기 위해 색상을 Hex 문자열로 관리했습니다.

Unity의 `Color` 또는 `Color32`를 사용할 수도 있지만, `<color=#RRGGBB>` 태그를 만들 때는 결국 `ColorUtility.ToHtmlStringRGB()`를 통한 문자열 변환이 필요합니다.  
현재는 고정된 UI 색상만 사용하므로 별도의 변환 과정 없이 Hex 문자열을 직접 사용하는 방식이 더 단순하다고 판단했습니다.

## UI 상태

- 일반: **`5턴`** 후 지급
- 지급 일시정지 (투기장): **대기** 중
- 손패 최대: 손패 **가득 참**
- 지급 직후: 카드 **지급!**

## 해결한 이슈
#258 