### PR TITLE
[Fix] 엘리트 노드 특수 기물 소개 팝업 개선

### DIFF
--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -11392,8 +11392,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 214080754}
-  - {fileID: 1661310177}
-  - {fileID: 2127569300}
+  - {fileID: 3200000201}
   m_Father: {fileID: 791655201}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -11414,7 +11413,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   baseEnabled: 0
-  fadeDuration: 0.2
+  fadeDuration: 0.3
   OnPanelEnabled:
     m_PersistentCalls:
       m_Calls: []
@@ -11430,6 +11429,11 @@ MonoBehaviour:
   nextButtonLabel: {fileID: 958804674}
   nextLabel: "\uB2E4\uC74C"
   closeLabel: "\uD655\uC778"
+  contentRoot: {fileID: 3200000201}
+  moveDistance: 240
+  moveDuration: 0.3
+  showEase: 6
+  hideEase: 5
 --- !u!114 &1460371063
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13729,7 +13733,7 @@ RectTransform:
   m_Children:
   - {fileID: 1680995455}
   - {fileID: 1309354266}
-  m_Father: {fileID: 1460371061}
+  m_Father: {fileID: 3200000201}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -22235,7 +22239,7 @@ RectTransform:
   - {fileID: 1609166960}
   - {fileID: 227286425}
   - {fileID: 240513493}
-  m_Father: {fileID: 1460371061}
+  m_Father: {fileID: 3200000201}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -22684,6 +22688,43 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
+--- !u!1 &3200000200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3200000201}
+  m_Layer: 5
+  m_Name: ContentRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3200000201
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1661310177}
+  - {fileID: 2127569300}
+  m_Father: {fileID: 1460371061}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3200000300
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -2326,6 +2326,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 199015196}
   m_CullTransparentMesh: 1
+--- !u!1 &214080753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 214080754}
+  - component: {fileID: 214080756}
+  - component: {fileID: 214080755}
+  m_Layer: 5
+  m_Name: BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &214080754
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 214080753}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1460371061}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &214080755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 214080753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.7607843}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &214080756
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 214080753}
+  m_CullTransparentMesh: 1
 --- !u!1 &227286424
 GameObject:
   m_ObjectHideFlags: 0
@@ -11316,6 +11391,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 214080754}
   - {fileID: 1661310177}
   - {fileID: 2127569300}
   m_Father: {fileID: 791655201}

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -11432,8 +11432,8 @@ MonoBehaviour:
   contentRoot: {fileID: 3200000201}
   moveDistance: 240
   moveDuration: 0.3
-  showEase: 6
-  hideEase: 5
+  showEase: 18
+  hideEase: 17
 --- !u!114 &1460371063
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13783,19 +13783,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1661310179}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1460371062}
-        m_TargetAssemblyTypeName: VariantPieceInfoPanel, Assembly-CSharp
-        m_MethodName: OnClickNext
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   clickSound: {fileID: 0}
   hoverSound: {fileID: 0}
   disableCanvas: {fileID: 0}
@@ -22697,6 +22685,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3200000201}
+  - component: {fileID: 3200000202}
   m_Layer: 5
   m_Name: ContentRoot
   m_TagString: Untagged
@@ -22725,6 +22714,18 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &3200000202
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200000200}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
 --- !u!1 &3200000300
 GameObject:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -13657,7 +13657,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -1425.8743}
+  m_AnchoredPosition: {x: 0, y: -1300}
   m_SizeDelta: {x: 1348.4, y: 206.19995}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1661310178
@@ -22164,7 +22164,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 1452.8}
-  m_SizeDelta: {x: 0, y: -2905.7}
+  m_SizeDelta: {x: 0, y: -2802.8}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &2127569301
 MonoBehaviour:

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
@@ -38,11 +38,19 @@ public class VariantPieceInfoPanel : ButtonPanel
     private readonly List<VariantPieceInfoSO.Entry> queue = new List<VariantPieceInfoSO.Entry>();
     private int index;
     private Vector2 shownPosition;
+    private CanvasGroup rootCanvasGroup;
+    private CanvasGroup contentCanvasGroup;
+    private bool isClosing;
 
     protected override void Awake()
     {
         base.Awake();
-        if (contentRoot != null) shownPosition = contentRoot.anchoredPosition;
+        rootCanvasGroup = GetComponent<CanvasGroup>();
+        if (contentRoot != null)
+        {
+            shownPosition = contentRoot.anchoredPosition;
+            contentCanvasGroup = contentRoot.GetComponent<CanvasGroup>();
+        }
     }
 
     /// <summary>주어진 변형 기물 종류들을 순서대로 설명합니다. 데이터가 없는 종류는 건너뜁니다.</summary>
@@ -65,11 +73,18 @@ public class VariantPieceInfoPanel : ButtonPanel
 
     public override void EnablePanel()
     {
+        isClosing = false;
+        if (rootCanvasGroup != null)
+            rootCanvasGroup.blocksRaycasts = true;
+        SetContentInput(false);
+
         if (contentRoot != null)
         {
             contentRoot.DOKill();
             contentRoot.anchoredPosition = shownPosition + Vector2.down * moveDistance;
-            contentRoot.DOAnchorPos(shownPosition, moveDuration).SetEase(showEase);
+            contentRoot.DOAnchorPos(shownPosition, moveDuration)
+                .SetEase(showEase)
+                .OnComplete(() => SetContentInput(true));
         }
 
         base.EnablePanel();
@@ -79,16 +94,35 @@ public class VariantPieceInfoPanel : ButtonPanel
 
     public override void DisablePanel()
     {
+        if (isClosing) return;
+        isClosing = true;
+
+        SetContentInput(false);
+
+        if (rootCanvasGroup != null && rootCanvasGroup.alpha <= 0.001f)
+        {
+            base.DisablePanel();
+            ReleaseInputBlock();
+            RestoreGameInput();
+            return;
+        }
+
         if (contentRoot != null)
         {
             contentRoot.DOKill();
             contentRoot.anchoredPosition = shownPosition;
             contentRoot.DOAnchorPos(shownPosition + Vector2.down * moveDistance, moveDuration)
-                .SetEase(hideEase);
+                .SetEase(hideEase)
+                .OnComplete(CompleteClose);
+        }
+        else
+        {
+            CompleteClose();
         }
 
         base.DisablePanel();
-        RestoreGameInput();
+        if (rootCanvasGroup != null)
+            rootCanvasGroup.blocksRaycasts = true;
     }
 
     // "확인" 버튼을 거치지 않고 씬 전환·부모 비활성화 등으로 패널이 닫히면 DisablePanel이 호출되지
@@ -101,6 +135,28 @@ public class VariantPieceInfoPanel : ButtonPanel
             contentRoot.anchoredPosition = shownPosition;
         }
 
+        SetContentInput(false);
+        ReleaseInputBlock();
+        RestoreGameInput();
+    }
+
+    private void SetContentInput(bool enabled)
+    {
+        if (contentCanvasGroup == null) return;
+
+        contentCanvasGroup.interactable = enabled;
+        contentCanvasGroup.blocksRaycasts = enabled;
+    }
+
+    private void ReleaseInputBlock()
+    {
+        if (rootCanvasGroup != null)
+            rootCanvasGroup.blocksRaycasts = false;
+    }
+
+    private void CompleteClose()
+    {
+        ReleaseInputBlock();
         RestoreGameInput();
     }
 
@@ -113,6 +169,8 @@ public class VariantPieceInfoPanel : ButtonPanel
     /// <summary>"다음" 버튼 OnClick에 연결합니다. 마지막 페이지에서는 패널을 닫습니다.</summary>
     public void OnClickNext()
     {
+        if (isClosing) return;
+
         index++;
         if (index >= queue.Count)
         {

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using DG.Tweening;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -27,8 +28,22 @@ public class VariantPieceInfoPanel : ButtonPanel
     [SerializeField] private string nextLabel = "다음";
     [SerializeField] private string closeLabel = "확인";
 
+    [Header("Animation")]
+    [SerializeField] private RectTransform contentRoot;
+    [SerializeField] private float moveDistance = 120f;
+    [SerializeField] private float moveDuration = 0.2f;
+    [SerializeField] private Ease showEase = Ease.OutCubic;
+    [SerializeField] private Ease hideEase = Ease.InCubic;
+
     private readonly List<VariantPieceInfoSO.Entry> queue = new List<VariantPieceInfoSO.Entry>();
     private int index;
+    private Vector2 shownPosition;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        if (contentRoot != null) shownPosition = contentRoot.anchoredPosition;
+    }
 
     /// <summary>주어진 변형 기물 종류들을 순서대로 설명합니다. 데이터가 없는 종류는 건너뜁니다.</summary>
     public void Show(IReadOnlyList<PieceType> types)
@@ -50,6 +65,13 @@ public class VariantPieceInfoPanel : ButtonPanel
 
     public override void EnablePanel()
     {
+        if (contentRoot != null)
+        {
+            contentRoot.DOKill();
+            contentRoot.anchoredPosition = shownPosition + Vector2.down * moveDistance;
+            contentRoot.DOAnchorPos(shownPosition, moveDuration).SetEase(showEase);
+        }
+
         base.EnablePanel();
         if (gameManager == null) gameManager = GameManager.Instance;
         if (gameManager != null) gameManager.IsGameInput = false;
@@ -57,6 +79,14 @@ public class VariantPieceInfoPanel : ButtonPanel
 
     public override void DisablePanel()
     {
+        if (contentRoot != null)
+        {
+            contentRoot.DOKill();
+            contentRoot.anchoredPosition = shownPosition;
+            contentRoot.DOAnchorPos(shownPosition + Vector2.down * moveDistance, moveDuration)
+                .SetEase(hideEase);
+        }
+
         base.DisablePanel();
         RestoreGameInput();
     }
@@ -65,6 +95,12 @@ public class VariantPieceInfoPanel : ButtonPanel
     // 않아 IsGameInput이 false로 남는 소프트락이 발생할 수 있으므로, OnDisable에서 안전하게 복구한다.
     private void OnDisable()
     {
+        if (contentRoot != null)
+        {
+            contentRoot.DOKill();
+            contentRoot.anchoredPosition = shownPosition;
+        }
+
         RestoreGameInput();
     }
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/VariantPieceInfoPanel.cs
@@ -135,6 +135,7 @@ public class VariantPieceInfoPanel : ButtonPanel
             contentRoot.anchoredPosition = shownPosition;
         }
 
+        isClosing = false;
         SetContentInput(false);
         ReleaseInputBlock();
         RestoreGameInput();


### PR DESCRIPTION
#262
## 개요

엘리트 노드 진입 시 표시되는 특수 기물 소개 팝업의 레이아웃과 동작을 개선했습니다.

## 변경 사항

- 긴 설명과 페이지 표시가 겹치지 않도록 팝업 크기 확대
- 팝업 배경 오버레이 추가
- 기존 페이드 효과와 함께 상하 이동 애니메이션 적용
- 애니메이션 중 팝업 및 게임 입력 차단
- 팝업 퇴장 완료 후 게임 입력 복구
- 전체 정보 영역의 중복 클릭 이벤트 제거
- 확인 버튼 연타 시 중복 종료 방지