### PR TITLE
[Chore] P9 전 카드 AI 메타데이터 기준 정리

### DIFF
--- a/ChaosChess_v2/Assets/Script/AIIntegration/Mapping/UnityCardInfoMapper.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Mapping/UnityCardInfoMapper.cs
@@ -70,6 +70,12 @@ namespace ChaosChess.Unity.AIIntegration.Mapping
             if (remainingUses < 0)
                 throw new ArgumentOutOfRangeException(nameof(remainingUses), remainingUses, "Remaining uses cannot be negative.");
 
+            if (!dataSO.AiSupported)
+            {
+                AddWarning(warnings, $"Skipped card '{dataSO.CardName}' because AiSupported is false.");
+                return false;
+            }
+
             if (string.IsNullOrWhiteSpace(dataSO.AiCardId))
             {
                 AddWarning(warnings, $"Skipped card '{dataSO.CardName}' because AiCardId is empty.");

--- a/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardDataSO.cs
@@ -89,6 +89,8 @@ public class CardDataSO : ScriptableObject
     public string AiCardId;
     [Tooltip("ChaosChess.AI CardInfo.Category에 사용하는 카드 분류입니다. Unknown이면 AI 후보에서 제외됩니다.")]
     public AiCardCategory AiCategory = AiCardCategory.Unknown;
+    [Tooltip("활성화된 카드만 ChaosChess.AI 후보로 전달합니다. P9 Supported subset을 명시적으로 제한하는 게이트입니다.")]
+    public bool AiSupported;
 
     [Space(30)]
     [Header("VFX 연출 설정")]

--- a/ChaosChess_v2/Assets/Script/Card/SO/AgileCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/AgileCard.asset
@@ -19,6 +19,9 @@ MonoBehaviour:
     (1\uD68C)"
   Type: 0
   CardTier: 0
+  AiCardId: agile
+  AiCategory: 30
+  AiSupported: 1
   VFX:
     ApplyVFXPrefab: {fileID: 0}
     LoopVFXPrefab: {fileID: 2763587446379904654, guid: c3514f54459cab5489bd06e933fbb69d, type: 3}

--- a/ChaosChess_v2/Assets/Script/Card/SO/ChargeCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/ChargeCard.asset
@@ -18,6 +18,9 @@ MonoBehaviour:
     <color=#4499FF>\uC55E\uC73C\uB85C 1\uCE78 \uC77C\uC81C\uD788 \uC804\uC9C4\uD569\uB2C8\uB2E4</color>."
   Type: 2
   CardTier: 1
+  AiCardId: charge
+  AiCategory: 30
+  AiSupported: 1
   VFX:
     ApplyVFXPrefab: {fileID: 0}
     LoopVFXPrefab: {fileID: 0}

--- a/ChaosChess_v2/Assets/Script/Card/SO/FireCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/FireCard.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   CardTier: 1
   AiCardId: fire
   AiCategory: 40
+  AiSupported: 1
   VFX:
     ApplyVFXPrefab: {fileID: 0}
     LoopVFXPrefab: {fileID: 0}

--- a/ChaosChess_v2/Assets/Script/Card/SO/PeaceZoneCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/PeaceZoneCard.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   CardTier: 2
   AiCardId: peace_zone
   AiCategory: 40
+  AiSupported: 1
   VFX:
     ApplyVFXPrefab: {fileID: 0}
     LoopVFXPrefab: {fileID: 0}

--- a/ChaosChess_v2/Assets/Script/Card/SO/PortalCard.asset
+++ b/ChaosChess_v2/Assets/Script/Card/SO/PortalCard.asset
@@ -18,6 +18,9 @@ MonoBehaviour:
     \uC124\uCE58\uD569\uB2C8\uB2E4."
   Type: 1
   CardTier: 2
+  AiCardId: portal
+  AiCategory: 30
+  AiSupported: 1
   VFX:
     ApplyVFXPrefab: {fileID: 0}
     LoopVFXPrefab: {fileID: 0}


### PR DESCRIPTION
## 개요

P9 `CardUsePlan` 계약 작업 전에 Unity 카드 카탈로그의 AI 메타데이터 기준을 정리합니다.

Related to 8x8-Labs/Chaos-Chess-v2#282

## 변경 내용

- `CardDataSO`에 `AiSupported` 게이트를 추가했습니다.
- `UnityCardInfoMapper`가 `AiSupported == true`인 카드만 ChaosChess.AI 후보로 전달하도록 변경했습니다.
- P9 초기 대표 subset 5종의 AI 메타데이터를 활성화했습니다.
  - `fire` / `BoardControl`
  - `peace_zone` / `BoardControl`
  - `agile` / `Mobility`
  - `portal` / `Mobility`
  - `charge` / `Mobility`

## 설계 사항

- `AiCardId`와 `AiCategory`가 있어도 `AiSupported`가 꺼져 있으면 AI 후보에서 제외됩니다.
- P9 전에 대표 카드 subset만 명시적으로 열어, 아직 target 계약이 없는 카드가 실수로 AI 실행 경로에 들어가지 않게 했습니다.
- P9의 `Supported/Unsupported` 계약, target DTO, validation, headless 해석은 이번 PR 범위에 포함하지 않았습니다.

## 제외 범위

- `CardUsePlan` 구현
- target DTO 구현
- plan validation 구현
- Unity plan 변환 구현
- headless simulator 카드 적용 구현
- 카드별 지능형 target strategy
- 카드 점수/threshold 튜닝
- random/history/mini-game 카드 exact 처리