### PR TITLE
[Refactor] UnifiedTurnPlanner Unity live path 연결

### DIFF
--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
@@ -121,6 +121,66 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                     failedCardSO);
             }
 
+            return ExecuteUnityPlan(plan, aiCardHand, boardManager, recommendation);
+        }
+
+        public AiCardExecutionResult ExecutePlan(
+            CardUsePlan usePlan,
+            AiCardHand aiCardHand,
+            global::BoardManager boardManager,
+            GameState gameState,
+            AiPieceColor actor)
+        {
+            if (usePlan == null)
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.NoRecommendation,
+                    "CardUsePlan is null.");
+            }
+
+            if (aiCardHand == null)
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.CardNotInHand,
+                    "AI card hand is null.");
+            }
+
+            if (!aiCardHand.TryFindByAiCardId(usePlan.CardId, out GameObject cardObject))
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.CardNotInHand,
+                    $"AI hand does not contain card id '{usePlan.CardId}'.");
+            }
+
+            if (!targetPlanner.TryCreatePlan(
+                    usePlan,
+                    cardObject,
+                    boardManager,
+                    gameState,
+                    actor,
+                    out AiCardTargetPlan plan,
+                    out AiCardExecutionStatus failureStatus,
+                    out string reason))
+            {
+                global::CardDataSO failedCardSO = cardObject != null
+                    ? GetCardDataSO(cardObject)
+                    : null;
+                return AiCardExecutionResult.Failure(
+                    failureStatus,
+                    reason,
+                    recommendation: null,
+                    cardSO: failedCardSO);
+            }
+
+            return ExecuteUnityPlan(plan, aiCardHand, boardManager, recommendation: null);
+        }
+
+        private static AiCardExecutionResult ExecuteUnityPlan(
+            AiCardTargetPlan plan,
+            AiCardHand aiCardHand,
+            global::BoardManager boardManager,
+            CardUseRecommendation recommendation)
+        {
             global::ICard cardExecutor = plan.CardData.GetComponent<global::ICard>();
             if (cardExecutor == null)
             {
@@ -137,7 +197,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                 aiCardHand.Consume(plan.CardData.DataSO);
                 boardManager?.RefreshMoves();
 
-                Debug.Log($"[AI Card] Executed '{plan.CardData.DataSO.CardName}' ({recommendation.Card.Id}) with {plan.UsePlan.Target.Kind} target.");
+                Debug.Log($"[AI Card] Executed '{plan.CardData.DataSO.CardName}' ({plan.UsePlan.CardId}) with {plan.UsePlan.Target.Kind} target.");
                 return AiCardExecutionResult.Success(recommendation, plan.CardData.DataSO);
             }
             catch (Exception ex)

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Runtime/AiTurnController.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Runtime/AiTurnController.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using ChaosChess.AI.Decision;
 using ChaosChess.AI.Decision.CardTargeting;
-using ChaosChess.AI.Evaluation;
+using ChaosChess.AI.Decision.TurnPlanning;
 using ChaosChess.Unity.AIIntegration.Cards;
 using ChaosChess.Unity.AIIntegration.Engine;
 using ChaosChess.Unity.AIIntegration.Mapping;
@@ -94,111 +94,386 @@ namespace ChaosChess.Unity.AIIntegration.Runtime
                     if (!IsActiveRequest(requestId))
                         return;
 
-                    bool shouldFallback = true;
                     try
                     {
-                        shouldFallback = HandleAnalysisComplete(
+                        HandleAnalysisComplete(
                             requestId,
                             gameManager,
                             boardManager,
                             hand,
                             mapping,
-                            snapshot);
+                            snapshot,
+                            fallbackMoveRequest);
                     }
                     catch (Exception ex)
                     {
-                        Debug.LogWarning($"[AI Turn] Card decision failed: {ex.Message}");
-                        shouldFallback = true;
+                        CompleteAndRequestFallback(
+                            requestId,
+                            fallbackMoveRequest,
+                            $"Turn planning failed: {ex.Message}");
                     }
-                    finally
-                    {
-                        CompleteRequest(requestId);
-                    }
-
-                    if (shouldFallback)
-                        fallbackMoveRequest?.Invoke();
                 },
                 onError: (_, error) =>
                 {
                     if (!IsActiveRequest(requestId))
                         return;
 
-                    Debug.LogWarning($"[AI Turn] Card analysis failed: {error}");
-                    CompleteRequest(requestId);
-                    fallbackMoveRequest?.Invoke();
+                    CompleteAndRequestFallback(
+                        requestId,
+                        fallbackMoveRequest,
+                        $"Card analysis failed: {error}");
                 });
 
             return true;
         }
 
-        private bool HandleAnalysisComplete(
+        private void HandleAnalysisComplete(
             int requestId,
             global::GameManager gameManager,
             global::BoardManager boardManager,
             AiCardHand hand,
             UnityGameStateMappingResult mapping,
-            UciAnalysisSnapshot snapshot)
+            UciAnalysisSnapshot snapshot,
+            Action fallbackMoveRequest)
         {
             if (!IsActiveRequest(requestId))
-                return false;
+                return;
 
             if (this == null || gameManager == null || boardManager == null)
-                return false;
+            {
+                CompleteRequest(requestId);
+                return;
+            }
 
             if (gameManager.IsEndGame)
-                return false;
+            {
+                CompleteRequest(requestId);
+                return;
+            }
 
             if (snapshot == null || !snapshot.HasMoves)
             {
-                Debug.LogWarning("[AI Turn] Card analysis returned no moves. Falling back to move only.");
-                return true;
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    "Card analysis returned no moves.");
+                return;
             }
 
-            var snapshotEngine = new FairyStockfishSnapshotEngine(
-                mapping.Fen,
-                snapshot,
-                FairyStockfishBridge.Instance.IsInCheck());
             var actor = UnityAiColorMapper.ToAiColor(gameManager.turnColor);
-            var evaluator = new GameStateEvaluator(
-                snapshotEngine,
-                new EvaluationOptions(searchDepth: analysisDepth));
-            EvaluationResult evaluation = evaluator.Evaluate(
-                mapping.GameState,
-                actor);
-            var decisionModule = new CardDecisionModule(
-                new ConfiguredCardScorer(BuildCategoryScores()),
-                new EloCardProfile(
-                    minimumScoreGain: Mathf.Max(0, minimumCardScoreGain),
-                    maximumCardsPerTurn: 1));
+            UnifiedTurnPlanner planner = CreateTurnPlanner(mapping.Fen, snapshot);
+            TurnPlannerResult result = planner.PlanTurn(mapping.GameState);
+            LogTurnPlannerTrace(result);
 
-            CardDecisionResult decision = decisionModule.Decide(
+            TurnPlan selectedPlan = result.SelectedPlan;
+            if (selectedPlan == null)
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    "UnifiedTurnPlanner selected no executable plan.");
+                return;
+            }
+
+            Debug.Log(
+                $"[AI Turn] Selected TurnPlan rank='{selectedPlan.DeterministicRankKey}', " +
+                $"usesCard={selectedPlan.UsesCard}, hasMove={selectedPlan.HasMove}, score={selectedPlan.Score.Total}.");
+
+            if (!selectedPlan.UsesCard)
+            {
+                ExecuteSelectedMoveOrFallback(
+                    requestId,
+                    gameManager,
+                    boardManager,
+                    selectedPlan.MovePlan,
+                    fallbackMoveRequest,
+                    "no-card TurnPlan");
+                return;
+            }
+
+            ExecuteCardPlanAndReanalyze(
+                requestId,
+                gameManager,
+                boardManager,
+                hand,
+                selectedPlan,
                 mapping.GameState,
-                evaluation,
                 actor,
-                cardTargetingModule,
-                engineTopMoves: snapshot.ToMoveCandidates());
-            AiCardExecutionResult execution = cardExecutor.ExecuteFirstRecommended(
-                decision,
+                fallbackMoveRequest);
+        }
+
+        private void ExecuteCardPlanAndReanalyze(
+            int requestId,
+            global::GameManager gameManager,
+            global::BoardManager boardManager,
+            AiCardHand hand,
+            TurnPlan selectedPlan,
+            ChaosChess.AI.Domain.GameState planningGameState,
+            ChaosChess.AI.Domain.PieceColor actor,
+            Action fallbackMoveRequest)
+        {
+            AiCardExecutionResult execution = cardExecutor.ExecutePlan(
+                selectedPlan.CardPlan,
                 hand,
                 boardManager,
-                mapping.GameState,
+                planningGameState,
                 actor);
 
             if (!execution.Executed)
             {
-                Debug.Log($"[AI Turn] No AI card executed: {execution.Status} - {execution.Reason}");
-                return true;
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    $"Selected card plan failed: {execution.Status} - {execution.Reason}");
+                return;
             }
-
-            boardManager.RefreshMoves();
 
             if (gameManager.FinishType != global::GameResult.None || gameManager.IsEndGame)
             {
                 gameManager.ReevaluateGameState();
-                return false;
+                CompleteRequest(requestId);
+                return;
             }
 
-            return true;
+            UnityGameStateMappingResult actualMapping;
+            try
+            {
+                actualMapping = UnityGameStateMapper.Capture(boardManager, hand);
+            }
+            catch (Exception ex)
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    $"Post-card actual state recapture failed: {ex.Message}");
+                return;
+            }
+
+            foreach (string warning in actualMapping.Warnings)
+                Debug.LogWarning($"[AI Turn] Post-card recapture: {warning}");
+
+            Debug.Log($"[AI Turn] Post-card actual state recaptured. Reanalyzing FEN: {actualMapping.Fen}");
+
+            var perspective = UnityAiColorMapper.ToAiColor(gameManager.turnColor);
+            FairyStockfishBridge.Instance.AnalyzePositionAsync(
+                actualMapping.Fen,
+                analysisDepth,
+                variationCount,
+                perspective,
+                onComplete: (_, postCardSnapshot) =>
+                {
+                    if (!IsActiveRequest(requestId))
+                        return;
+
+                    try
+                    {
+                        HandlePostCardAnalysisComplete(
+                            requestId,
+                            gameManager,
+                            boardManager,
+                            actualMapping,
+                            selectedPlan,
+                            postCardSnapshot,
+                            fallbackMoveRequest);
+                    }
+                    catch (Exception ex)
+                    {
+                        CompleteAndRequestFallback(
+                            requestId,
+                            fallbackMoveRequest,
+                            $"Post-card move planning failed: {ex.Message}");
+                    }
+                },
+                onError: (_, error) =>
+                {
+                    if (!IsActiveRequest(requestId))
+                        return;
+
+                    CompleteAndRequestFallback(
+                        requestId,
+                        fallbackMoveRequest,
+                        $"Post-card analysis failed: {error}");
+                });
+        }
+
+        private void HandlePostCardAnalysisComplete(
+            int requestId,
+            global::GameManager gameManager,
+            global::BoardManager boardManager,
+            UnityGameStateMappingResult actualMapping,
+            TurnPlan originalPlan,
+            UciAnalysisSnapshot postCardSnapshot,
+            Action fallbackMoveRequest)
+        {
+            if (!IsActiveRequest(requestId))
+                return;
+
+            if (this == null || gameManager == null || boardManager == null)
+            {
+                CompleteRequest(requestId);
+                return;
+            }
+
+            if (gameManager.IsEndGame)
+            {
+                CompleteRequest(requestId);
+                return;
+            }
+
+            if (postCardSnapshot == null || !postCardSnapshot.HasMoves)
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    "Post-card analysis returned no moves.");
+                return;
+            }
+
+            var snapshotEngine = new FairyStockfishSnapshotEngine(
+                actualMapping.Fen,
+                postCardSnapshot,
+                FairyStockfishBridge.Instance.IsInCheck());
+            var moveFilter = new MoveFilter(snapshotEngine);
+            MoveFilterResult moveResult = moveFilter.GetFilteredMoves(
+                actualMapping.GameState,
+                variationCount);
+
+            if (!moveResult.HasRecommendations)
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    "Post-card MoveFilter returned no executable recommendations.");
+                return;
+            }
+
+            MoveRecommendation recommendation = moveResult.Recommendations[0];
+            if (originalPlan.MovePlan != null &&
+                !string.Equals(originalPlan.MovePlan.UciMove, recommendation.Candidate.UciMove, StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.LogWarning(
+                    $"[AI Turn] Simulated/actual move mismatch. Planned '{originalPlan.MovePlan.UciMove}', " +
+                    $"actual filtered '{recommendation.Candidate.UciMove}'. Using actual filtered move.");
+            }
+
+            ExecuteUciMoveOrFallback(
+                requestId,
+                gameManager,
+                boardManager,
+                recommendation.Candidate.UciMove,
+                fallbackMoveRequest,
+                "post-card actual MoveFilter");
+        }
+
+        private UnifiedTurnPlanner CreateTurnPlanner(
+            string fen,
+            UciAnalysisSnapshot snapshot)
+        {
+            var snapshotEngine = new FairyStockfishSnapshotEngine(
+                fen,
+                snapshot,
+                FairyStockfishBridge.Instance.IsInCheck());
+            var moveFilter = new MoveFilter(snapshotEngine);
+            var options = new TurnPlannerOptions(
+                noCardMoveCandidateCount: variationCount,
+                postCardMoveCandidateCount: variationCount,
+                opponentReplyCandidateCount: 0,
+                beamWidth: Mathf.Max(1, variationCount));
+
+            return new UnifiedTurnPlanner(
+                moveFilter,
+                cardTargetingModule,
+                options: options);
+        }
+
+        private void ExecuteSelectedMoveOrFallback(
+            int requestId,
+            global::GameManager gameManager,
+            global::BoardManager boardManager,
+            MovePlan movePlan,
+            Action fallbackMoveRequest,
+            string source)
+        {
+            if (movePlan == null)
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    $"{source} did not contain a move plan.");
+                return;
+            }
+
+            ExecuteUciMoveOrFallback(
+                requestId,
+                gameManager,
+                boardManager,
+                movePlan.UciMove,
+                fallbackMoveRequest,
+                source);
+        }
+
+        private void ExecuteUciMoveOrFallback(
+            int requestId,
+            global::GameManager gameManager,
+            global::BoardManager boardManager,
+            string uciMove,
+            Action fallbackMoveRequest,
+            string source)
+        {
+            if (!IsActiveRequest(requestId))
+                return;
+
+            if (this == null || gameManager == null || boardManager == null)
+            {
+                CompleteRequest(requestId);
+                return;
+            }
+
+            if (gameManager.IsEndGame)
+            {
+                CompleteRequest(requestId);
+                return;
+            }
+
+            if (!boardManager.IsValidUciMove(uciMove))
+            {
+                CompleteAndRequestFallback(
+                    requestId,
+                    fallbackMoveRequest,
+                    $"{source} selected invalid UCI move '{uciMove}'.");
+                return;
+            }
+
+            Debug.Log($"[AI Turn] Executing {source} move '{uciMove}'.");
+            CompleteRequest(requestId);
+            boardManager.ApplyUCIMove(uciMove);
+        }
+
+        private void CompleteAndRequestFallback(
+            int requestId,
+            Action fallbackMoveRequest,
+            string reason)
+        {
+            if (!IsActiveRequest(requestId))
+                return;
+
+            Debug.LogWarning($"[AI Turn] Falling back to move-only path: {reason}");
+            CompleteRequest(requestId);
+            fallbackMoveRequest?.Invoke();
+        }
+
+        private static void LogTurnPlannerTrace(TurnPlannerResult result)
+        {
+            if (result == null)
+                return;
+
+            TurnPlannerTraceSummary trace = result.TraceSummary;
+            Debug.Log(
+                "[AI Turn] UnifiedTurnPlanner trace: " +
+                $"selected={trace.SelectedCandidateCount}, skipped={trace.SkippedCandidateCount}, " +
+                $"rootMoves={trace.RootNoCardMoveCandidateCount}, consideredCards={trace.ConsideredCardCandidateCount}, " +
+                $"postCardMoves={trace.PostCardMoveCandidateCount}, engineCalls={trace.EngineCallCount}/{trace.MaximumEngineCallCount}, " +
+                $"beamPruned={trace.BeamPrunedCandidateCount}.");
         }
 
         private AiCardHand ResolveCardHand()


### PR DESCRIPTION
## 개요

P13.5에서 Unity AI 턴 실행 경로를 ChaosChess.AI `v0.5.0`의 `UnifiedTurnPlanner` public API에 연결합니다.

이번 PR은 기존 AI 카드 후보 판단을 턴 단위 계획으로 교체하고, 카드 실행 후 Unity 실제 보드 상태를 다시 캡처/재분석한 뒤 live `MoveFilter` 결과로 최종 이동을 적용하는 단계입니다.

## Related to

- Closes 8x8-Labs/Chaos-Chess-v2#296
- parent: 8x8-Labs/Chaos-Chess-v2#292
- prerequisite Unity PR: 8x8-Labs/Chaos-Chess-v2#295
- prerequisite AI PR: 8x8-Labs/ChaosChess.AI#19
- AI release: 8x8-Labs/ChaosChess.AI@v0.5.0

## 변경 내용

- `AiTurnController`에서 `UnifiedTurnPlanner.PlanTurn()`을 호출하도록 Unity AI 턴 경로를 연결
- `TurnPlan`의 no-card move plan을 기존 Unity UCI move 실행 경로로 적용
- `TurnPlan.CardPlan`을 Unity 카드 실행 경계에서 소비할 수 있도록 `AiCardExecutor.ExecutePlan(CardUsePlan, ...)` 추가
- 카드 실행 후 실제 Unity 보드 상태를 recapture하고 새 FEN으로 post-card analysis 수행
- post-card actual state 기준으로 `MoveFilter`를 재적용해 최종 UCI move 실행
- fallback 처리를 `CompleteAndRequestFallback()`로 모아 move-only fallback 중복 실행 위험 완화
- `UnifiedTurnPlanner` trace와 simulated/actual move mismatch 로그 추가

## 제외 범위

- ChaosChess.AI DLL pin 변경
- `ChaosChessAiVersion` 변경
- Scene/Prefab/ScriptableObject 변경
- `.meta` 파일 변경
- `AiSupported` 카드 활성화 변경
- 카드 점수/threshold 밸런싱
- Unity Play Mode 실행
- Unity batchmode/CLI build 실행
- P13.5 parent issue close