### PR TITLE
[Fix] AI 카드 실행 caster 전달 보정

### DIFF
--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
@@ -197,7 +197,10 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                 aiCardHand.Consume(plan.CardData.DataSO);
                 boardManager?.RefreshMoves();
 
-                Debug.Log($"[AI Card] Executed '{plan.CardData.DataSO.CardName}' ({plan.UsePlan.CardId}) with {plan.UsePlan.Target.Kind} target.");
+                Debug.Log(
+                    $"[AI Card] Executed '{plan.CardData.DataSO.CardName}' ({plan.UsePlan.CardId}), " +
+                    $"caster={FormatCaster(plan)}, target={plan.UsePlan.Target.Kind}, " +
+                    $"squares={FormatTargetSquares(plan)}.");
                 return AiCardExecutionResult.Success(recommendation, plan.CardData.DataSO);
             }
             catch (Exception ex)
@@ -218,6 +221,28 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                 : null;
 
             return cardData != null ? cardData.DataSO : null;
+        }
+
+        private static string FormatTargetSquares(AiCardTargetPlan plan)
+        {
+            if (plan == null || plan.UsePlan == null || plan.UsePlan.Target == null)
+                return "none";
+
+            if (plan.UsePlan.Target.Squares.Count == 0)
+                return "none";
+
+            var labels = new string[plan.UsePlan.Target.Squares.Count];
+            for (int i = 0; i < labels.Length; i++)
+                labels[i] = plan.UsePlan.Target.Squares[i].ToString();
+
+            return string.Join(",", labels);
+        }
+
+        private static string FormatCaster(AiCardTargetPlan plan)
+        {
+            return plan != null && plan.Args != null
+                ? plan.Args.ResolveCasterColor().ToString()
+                : "unknown";
         }
     }
 }

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardTargetPlanner.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardTargetPlanner.cs
@@ -556,6 +556,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
             switch (usePlan.Target.Kind)
             {
                 case CardTargetKind.None:
+                    args = CreateUnityArgs(usePlan);
                     return true;
 
                 case CardTargetKind.PieceAtSquare:
@@ -563,11 +564,9 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                         return false;
 
                     var pieces = new List<global::Piece> { piece };
-                    args = new global::CardEffectArgs
-                    {
-                        Targets = pieces,
-                        LimitTurn = cardData.DataSO.PieceLimitTurn
-                    };
+                    args = CreateUnityArgs(usePlan);
+                    args.Targets = pieces;
+                    args.LimitTurn = cardData.DataSO.PieceLimitTurn;
                     targetPieces = pieces;
                     return true;
 
@@ -579,11 +578,9 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                         positions.Add(ToVector3Int(square));
                     }
 
-                    args = new global::CardEffectArgs
-                    {
-                        TargetPos = positions,
-                        LimitTurn = cardData.DataSO.MaintainTurn
-                    };
+                    args = CreateUnityArgs(usePlan);
+                    args.TargetPos = positions;
+                    args.LimitTurn = cardData.DataSO.MaintainTurn;
                     targetPositions = positions;
                     return true;
 
@@ -591,6 +588,15 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                     reason = $"Unsupported CardUsePlan target kind '{usePlan.Target.Kind}'.";
                     return false;
             }
+        }
+
+        private static global::CardEffectArgs CreateUnityArgs(CardUsePlan usePlan)
+        {
+            return new global::CardEffectArgs
+            {
+                HasCasterColor = true,
+                CasterColor = ToUnityColor(usePlan.Actor)
+            };
         }
 
         private bool CanSelectPiece(
@@ -735,6 +741,13 @@ namespace ChaosChess.Unity.AIIntegration.Cards
             return color == global::PieceColor.White
                 ? AiPieceColor.White
                 : AiPieceColor.Black;
+        }
+
+        private static global::PieceColor ToUnityColor(AiPieceColor color)
+        {
+            return color == AiPieceColor.White
+                ? global::PieceColor.White
+                : global::PieceColor.Black;
         }
 
         private static AiPieceKind ToAiPieceKind(global::PieceType type)

--- a/ChaosChess_v2/Assets/Script/Card/CardData.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardData.cs
@@ -59,4 +59,21 @@ public class CardEffectArgs
     public List<Piece> Targets;             // 선택된 기물들
     public List<Vector3Int> TargetPos;      // 선택된 좌표
     public int LimitTurn;                   // 적용 턴 수치
+    public bool HasCasterColor;             // AI 실행 경로처럼 시전자를 명시적으로 전달하는 경우 true
+    public PieceColor CasterColor;          // 카드를 시전한 색상
+
+    public PieceColor ResolveCasterColor()
+    {
+        if (HasCasterColor)
+            return CasterColor;
+
+        return ResolveDefaultCasterColor();
+    }
+
+    public static PieceColor ResolveDefaultCasterColor()
+    {
+        return GameManager.Instance != null
+            ? GameManager.Instance.turnColor
+            : PieceColor.White;
+    }
 }

--- a/ChaosChess_v2/Assets/Script/Card/Skills/PortalCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/Skills/PortalCard.cs
@@ -34,7 +34,9 @@ public class PortalSkill : CardData, ITileCard
         portalA.SharedUses = sharedUses;
         portalB.SharedUses = sharedUses;
 
-        PieceColor casterColor = GameManager.Instance.PlayerColor;
+        PieceColor casterColor = args != null
+            ? args.ResolveCasterColor()
+            : CardEffectArgs.ResolveDefaultCasterColor();
         portalA.CasterColor = casterColor;
         portalB.CasterColor = casterColor;
 

--- a/ChaosChess_v2/Assets/Script/Card/skills/ChargeCard.cs
+++ b/ChaosChess_v2/Assets/Script/Card/skills/ChargeCard.cs
@@ -11,9 +11,11 @@ public class ChargeCard : CardData, ICard
     {
         BoardManager bm = BoardManager.Instance;
 
-        PieceColor myColor = GameManager.Instance.PlayerColor;
-        int advanceDir = 1;
-        int promotionRow = 7;
+        PieceColor myColor = args != null
+            ? args.ResolveCasterColor()
+            : CardEffectArgs.ResolveDefaultCasterColor();
+        int advanceDir = myColor == PieceColor.White ? 1 : -1;
+        int promotionRow = myColor == PieceColor.White ? 7 : 0;
 
         List<Piece> myPawns = bm.GetAllPieces()
             .FindAll(p => p.Color == myColor && p.Type == PieceType.Pawn);


### PR DESCRIPTION
## 개요

P14 카드 활성화 전에 필요한 Unity 카드 실행 경로의 caster/owner 의미를 보정합니다.

AI가 카드를 실행할 때 `actor`가 Unity `CardEffectArgs`까지 전달되지 않아, 일부 카드가 `GameManager.PlayerColor` 기준으로 실행될 수 있던 문제를 수정합니다.

## Related to

- 8x8-Labs/Chaos-Chess-v2#298
- parent: 8x8-Labs/Chaos-Chess-v2#292

## 변경 내용

- `CardEffectArgs`에 명시적 caster color 전달 필드 추가
- AI `CardUsePlan.Actor`를 Unity `PieceColor`로 변환해 카드 실행 args에 주입
- `ChargeCard`가 caster 기준으로 폰 색상, 진행 방향, 승격 행을 계산하도록 수정
- `PortalCard`가 caster 기준으로 `PortalEffect.CasterColor`를 저장하도록 수정
- AI 카드 실행 로그에 caster, target kind, target squares 출력 추가

## 제외 범위

- AI core/DLL 변경
- 카드 45장 metadata 매핑
- `AiSupported` 변경
- Fire 타겟 지능 개선
- Scene/Prefab/ScriptableObject 변경
- Unity Play Mode 자동 테스트 추가
- P14 이슈 close