### PR TITLE
[Feature] AI 덱/손패 관리 및 카드 규칙 동기화

### DIFF
--- a/ChaosChess_v2/Assets/Editor/AiCardDebugWindow.cs
+++ b/ChaosChess_v2/Assets/Editor/AiCardDebugWindow.cs
@@ -20,6 +20,7 @@ public sealed class AiCardDebugWindow : EditorWindow
     [SerializeField] private AiCardHand aiCardHand;
     [SerializeField] private BoardManager boardManager;
     [SerializeField] private GameManager gameManager;
+    [SerializeField] private MapManager mapManager;
     [SerializeField] private AiTurnController aiTurnController;
     [SerializeField] private int selectedCatalogIndex;
     [SerializeField] private int selectedHandIndex;
@@ -28,6 +29,7 @@ public sealed class AiCardDebugWindow : EditorWindow
     [SerializeField] private bool showSceneReferences;
     [SerializeField] private bool showPreset;
     [SerializeField] private bool showSelectedCardDetails;
+    [SerializeField] private bool showAllNodeDecks = true;
     [SerializeField] private int allCardsBatchIndex;
 
     private readonly AiCardTargetPlanner targetPlanner = new AiCardTargetPlanner();
@@ -37,6 +39,7 @@ public sealed class AiCardDebugWindow : EditorWindow
     private readonly StringBuilder logBuilder = new StringBuilder(8192);
     private Vector2 scroll;
     private Vector2 catalogScroll;
+    private Vector2 deckScroll;
     private Vector2 handScroll;
     private Vector2 handPageScroll;
     private int observedHandVersion = -1;
@@ -46,7 +49,7 @@ public sealed class AiCardDebugWindow : EditorWindow
     private bool autoScanDirty = true;
     private string lastAutoScanFingerprint;
     private double nextAutoScanAt;
-    private static readonly string[] Tabs = { "Hand", "Cards", "Log" };
+    private static readonly string[] Tabs = { "Hand", "Cards", "Decks", "Log" };
     private static readonly TestHandPreset[] TestHandPresets =
     {
         new TestHandPreset(
@@ -183,6 +186,9 @@ public sealed class AiCardDebugWindow : EditorWindow
                 DrawCompactCatalogView();
                 break;
             case 2:
+                DrawDecksView();
+                break;
+            case 3:
                 DrawLogPanel();
                 break;
         }
@@ -223,6 +229,7 @@ public sealed class AiCardDebugWindow : EditorWindow
                     aiCardHand = (AiCardHand)EditorGUILayout.ObjectField("AI Hand", aiCardHand, typeof(AiCardHand), true);
                     boardManager = (BoardManager)EditorGUILayout.ObjectField("Board", boardManager, typeof(BoardManager), true);
                     gameManager = (GameManager)EditorGUILayout.ObjectField("Game", gameManager, typeof(GameManager), true);
+                    mapManager = (MapManager)EditorGUILayout.ObjectField("Map", mapManager, typeof(MapManager), true);
                     aiTurnController = (AiTurnController)EditorGUILayout.ObjectField("AI Turn", aiTurnController, typeof(AiTurnController), true);
                     if (EditorGUI.EndChangeCheck())
                     {
@@ -462,6 +469,152 @@ public sealed class AiCardDebugWindow : EditorWindow
         }
     }
 
+    private void DrawDecksView()
+    {
+        deckScroll = EditorGUILayout.BeginScrollView(deckScroll);
+
+        using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.LabelField("AI Runtime Decks", EditorStyles.boldLabel);
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button("Refresh", GUILayout.Width(80f)))
+                {
+                    ResolveSceneReferences();
+                    Repaint();
+                }
+            }
+
+            mapManager = (MapManager)EditorGUILayout.ObjectField("Map Manager", mapManager, typeof(MapManager), true);
+
+            if (mapManager == null)
+            {
+                EditorGUILayout.HelpBox("MapManager가 없어서 노드별 AI 덱을 볼 수 없습니다. 런 또는 연습모드를 시작한 뒤 확인하세요.", MessageType.Info);
+                EditorGUILayout.EndScrollView();
+                return;
+            }
+
+            EditorGUILayout.LabelField("Mode", GameCycleManager.Instance != null ? GameCycleManager.Instance.CurrentMode.ToString() : "Unknown");
+            EditorGUILayout.LabelField("Maps", mapManager.maps != null ? mapManager.maps.Count.ToString() : "0");
+        }
+
+        if (mapManager.curMap != null)
+        {
+            DrawMapDeck("Current Node", mapManager.curMap, true);
+            EditorGUILayout.Space(6f);
+        }
+
+        showAllNodeDecks = EditorGUILayout.Foldout(showAllNodeDecks, "All Nodes", true);
+        if (showAllNodeDecks)
+        {
+            foreach (Map map in GetDeckViewMaps())
+                DrawMapDeck(FormatMapNodeLabel(map), map, false);
+        }
+
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void DrawMapDeck(string title, Map map, bool showCopyButton)
+    {
+        if (map == null)
+            return;
+
+        IReadOnlyList<GameObject> deckCards = mapManager != null
+            ? mapManager.ResolveAiRuntimeDeckCards(map)
+            : Array.Empty<GameObject>();
+        List<string> deckIds = map.AiRuntimeDeckCardIds ?? new List<string>();
+
+        using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.LabelField(title, EditorStyles.boldLabel);
+                GUILayout.FlexibleSpace();
+                EditorGUILayout.LabelField(deckCards.Count + " cards", GUILayout.Width(72f));
+
+                if (showCopyButton && GUILayout.Button("Copy IDs", GUILayout.Width(76f)))
+                {
+                    EditorGUIUtility.systemCopyBuffer = string.Join(", ", deckIds);
+                    AppendLog("Copied current AI runtime deck ids: " + deckIds.Count);
+                }
+            }
+
+            EditorGUILayout.LabelField("Node", FormatMapNodeLabel(map));
+            EditorGUILayout.LabelField("Config", map.AiDeckConfig != null ? map.AiDeckConfig.DeckId : "<runtime>");
+            EditorGUILayout.LabelField("Ids", deckIds.Count > 0 ? string.Join(", ", deckIds) : "<empty>");
+
+            if (deckCards.Count == 0)
+            {
+                EditorGUILayout.HelpBox("이 노드에 표시할 AI 런타임 덱 카드가 없습니다.", MessageType.Warning);
+                return;
+            }
+
+            for (int i = 0; i < deckCards.Count; i++)
+                DrawDeckCardRow(i, deckCards[i]);
+        }
+    }
+
+    private void DrawDeckCardRow(int index, GameObject cardObject)
+    {
+        CardData card = GetCardData(cardObject);
+        CardDataSO so = card != null ? card.DataSO : null;
+
+        using (new EditorGUILayout.HorizontalScope())
+        {
+            EditorGUILayout.LabelField((index + 1).ToString(), GUILayout.Width(28f));
+            EditorGUILayout.LabelField(FormatCardLabel(card));
+
+            using (new EditorGUI.DisabledScope(so == null))
+            {
+                if (GUILayout.Button(new GUIContent("SO", "Select this card's CardDataSO in the Inspector."), GUILayout.Width(34f)))
+                    SelectCardDataSO(so);
+            }
+
+            using (new EditorGUI.DisabledScope(cardObject == null))
+            {
+                if (GUILayout.Button(new GUIContent("Prefab", "Select this card prefab in the Project window."), GUILayout.Width(58f)))
+                {
+                    Selection.activeObject = cardObject;
+                    EditorGUIUtility.PingObject(cardObject);
+                }
+            }
+        }
+    }
+
+    private IEnumerable<Map> GetDeckViewMaps()
+    {
+        if (mapManager == null)
+            yield break;
+
+        if (mapManager.mapGrid != null && mapManager.mapGrid.Count > 0)
+        {
+            foreach (MapFloor floor in mapManager.mapGrid)
+            {
+                if (floor?.nodes == null)
+                    continue;
+
+                foreach (Map node in floor.nodes)
+                {
+                    if (node != null)
+                        yield return node;
+                }
+            }
+
+            yield break;
+        }
+
+        if (mapManager.maps == null)
+            yield break;
+
+        foreach (Map map in mapManager.maps)
+        {
+            if (map != null)
+                yield return map;
+        }
+    }
+
     private void DrawLogPanel()
     {
         using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
@@ -508,6 +661,9 @@ public sealed class AiCardDebugWindow : EditorWindow
 
         if (gameManager == null)
             gameManager = GameManager.Instance != null ? GameManager.Instance : UnityEngine.Object.FindFirstObjectByType<GameManager>();
+
+        if (mapManager == null)
+            mapManager = MapManager.Instance != null ? MapManager.Instance : UnityEngine.Object.FindFirstObjectByType<MapManager>();
 
         if (aiTurnController == null)
             aiTurnController = UnityEngine.Object.FindFirstObjectByType<AiTurnController>();
@@ -564,6 +720,7 @@ public sealed class AiCardDebugWindow : EditorWindow
         return aiCardHand == null ||
                boardManager == null ||
                gameManager == null ||
+               mapManager == null ||
                aiTurnController == null;
     }
 
@@ -1494,6 +1651,15 @@ public sealed class AiCardDebugWindow : EditorWindow
         string name = string.IsNullOrWhiteSpace(so.CardName) ? card.name : so.CardName;
         string aiId = string.IsNullOrWhiteSpace(so.AiCardId) ? "no-ai-id" : so.AiCardId;
         return name + " [" + so.Type + ", " + aiId + "]";
+    }
+
+    private static string FormatMapNodeLabel(Map map)
+    {
+        if (map == null)
+            return "<null>";
+
+        string name = string.IsNullOrWhiteSpace(map.MapName) ? "<unnamed>" : map.MapName;
+        return name + " (" + map.nodeType + ", floor=" + map.floor + ", column=" + map.column + ")";
     }
 
     private static string FormatStateSummary(UnityGameStateMappingResult mapping)

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene.unity
@@ -11650,6 +11650,8 @@ MonoBehaviour:
   curTurn: 1
   IsGameInput: 1
   AiAutoMoveEnabled: 1
+  autoCreateAiCardController: 1
+  aiTurnController: {fileID: 0}
 --- !u!1 &1388570847
 GameObject:
   m_ObjectHideFlags: 0
@@ -16419,6 +16421,95 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1837571695}
   m_CullTransparentMesh: 1
+--- !u!1 &1844013817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1844013820}
+  - component: {fileID: 1844013819}
+  - component: {fileID: 1844013818}
+  m_Layer: 0
+  m_Name: AI Card System
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1844013818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844013817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c63021decd671d547a647e836ff3027f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  aiCardUsageEnabled: 1
+  aiCardHand: {fileID: 1844013819}
+  analysisDepth: 12
+  variationCount: 3
+  cardCandidateCount: 4
+  targetCandidateCount: 32
+  opponentReplyCandidateCount: 1
+  maximumEngineCallCount: 64
+  allowCoarseCardEffects: 1
+  cardUseScoreTolerance: 120
+  fullHandCardUseScoreTolerance: 1000
+  directCardFallbackEnabled: 0
+  tacticalScore: 10
+  defensiveScore: 8
+  mobilityScore: 8
+  boardControlScore: 10
+  summonScore: 7
+  transformationScore: 7
+  utilityScore: 5
+--- !u!114 &1844013819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844013817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04c29f31ef20e71469adc58e9542365f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startingCards: []
+  defaultRemainingUses: 1
+  useEditorConfiguredStartingCards: 0
+  editorStartingCardPrefabPaths: []
+  useDeckRuntime: 1
+  deckConfigOverride: {fileID: 0}
+  useMapDeckConfig: 1
+  useAllSupportedCardsWhenDeckMissing: 1
+  fallbackInitialHandCount: 4
+  fallbackDrawIntervalTurns: 5
+  fallbackDrawCount: 1
+  fallbackReshuffleUsedPileWhenEmpty: 0
+  logDeckState: 0
+--- !u!4 &1844013820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844013817}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1860162442
 GameObject:
   m_ObjectHideFlags: 0
@@ -24046,3 +24137,4 @@ SceneRoots:
   - {fileID: 817329984}
   - {fileID: 980504690}
   - {fileID: 1957615140}
+  - {fileID: 1844013820}

--- a/ChaosChess_v2/Assets/Scenes/MainGameScene_AITest.unity
+++ b/ChaosChess_v2/Assets/Scenes/MainGameScene_AITest.unity
@@ -169,8 +169,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.97742105, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -207,8 +207,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -250,7 +250,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -264,7 +264,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -316,8 +316,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -453,8 +453,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -648,8 +648,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_RenderShadows: 1
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
@@ -692,8 +692,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 56666c5a40171f54783dd416a44f42bf, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_EventMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -708,8 +708,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d6c8ef68b9bb96b4dbc6c5ea9d017172, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   boardSize: 6
 --- !u!1 &36723180
 GameObject:
@@ -758,8 +758,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -815,8 +815,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -832,8 +832,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -937,8 +937,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.8352941}
   m_RaycastTarget: 0
@@ -1015,8 +1015,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.9411765}
   m_RaycastTarget: 1
@@ -1065,8 +1065,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9b887b2b32e8ed04e80ca7d13765b344, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -1081,7 +1081,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   OnPanelDisabled:
@@ -1096,7 +1096,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!1 &74429212
@@ -1146,8 +1146,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1379,8 +1379,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9b887b2b32e8ed04e80ca7d13765b344, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -1448,8 +1448,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1585,8 +1585,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.9372549}
   m_RaycastTarget: 1
@@ -1660,8 +1660,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1799,8 +1799,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 0
@@ -2133,7 +2133,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8982855325810294302, guid: c01b6ebfca71c7043bfc6817e00d3d62, type: 3}
       propertyPath: m_Camera
-      value:
+      value: 
       objectReference: {fileID: 14408963}
     - target: {fileID: 8982855325810294302, guid: c01b6ebfca71c7043bfc6817e00d3d62, type: 3}
       propertyPath: m_SortingOrder
@@ -2170,8 +2170,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9b887b2b32e8ed04e80ca7d13765b344, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &161357343
 GameObject:
   m_ObjectHideFlags: 0
@@ -2222,8 +2222,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2300,8 +2300,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.23899364, g: 0.22861303, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -2377,8 +2377,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -2448,8 +2448,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.7607843}
   m_RaycastTarget: 1
@@ -2523,8 +2523,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2668,8 +2668,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -2733,8 +2733,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -2771,8 +2771,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -2814,7 +2814,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 8300000, guid: e1a84ab5827257b42a802c0d89ba6464, type: 3}
@@ -2828,7 +2828,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -2843,8 +2843,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 60830b44ee17d524e83e5bafa6b1a953, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!222 &253057115
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2897,8 +2897,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -2914,8 +2914,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -2984,8 +2984,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 72691c85cfe59fd44876b5e3f68e0570, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -3192,8 +3192,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3252,8 +3252,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.9648957, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -3319,8 +3319,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3394,8 +3394,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3531,8 +3531,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3671,8 +3671,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 9527febdf2ae1e449ab1eaf04a665ea7, type: 2}
   m_Color: {r: 0.05882353, g: 0.12941177, b: 0.24705882, a: 1}
   m_RaycastTarget: 1
@@ -3709,8 +3709,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -3754,7 +3754,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -3806,8 +3806,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 8f40f04e7bbbae348b09552d6ec016ab, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3881,8 +3881,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4021,8 +4021,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 324fdd3ea78fab743bb1f3de9bc5898a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &475878340
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4033,8 +4033,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4076,7 +4076,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -4090,7 +4090,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -4105,8 +4105,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4176,8 +4176,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0c49a518f6a128143aecd5e77dbd391b, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 9783473a218a7b74b837c6277fa570c7, type: 2}
   bgmSource: {fileID: 507959204}
   cardUseSFXByTier:
@@ -4345,8 +4345,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.8862745}
   m_RaycastTarget: 0
@@ -4421,8 +4421,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
 --- !u!114 &537971875
@@ -4435,8 +4435,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4573,8 +4573,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4710,8 +4710,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: dd1754d95893f5745b21219f91e1363b, type: 2}
   m_Color: {r: 0.30817598, g: 0.30817598, b: 0.30817598, a: 1}
   m_RaycastTarget: 1
@@ -4765,8 +4765,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8ad54f70766ab4f4ea9275f391bcf377, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &584636419
 Transform:
   m_ObjectHideFlags: 0
@@ -4836,8 +4836,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding: {x: 0, y: 0, z: 0, w: 0}
   m_Softness: {x: 0, y: 0}
 --- !u!114 &593770055
@@ -4850,8 +4850,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 003ea7247916de143ab9d1db6da03103, type: 2}
   m_Color: {r: 0.08176088, g: 0.08176088, b: 0.08176088, a: 1}
   m_RaycastTarget: 1
@@ -4888,8 +4888,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e02fe3b58939a574a86bc7c36bfe4281, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   iconImage: {fileID: 36723182}
   rotateAngle: 8
   rotateDuration: 1.6
@@ -4907,8 +4907,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -4952,7 +4952,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -5004,8 +5004,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5148,8 +5148,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding: {x: 0, y: 0, z: 0, w: 0}
   m_Softness: {x: 0, y: 0}
 --- !u!114 &613843185
@@ -5162,8 +5162,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 003ea7247916de143ab9d1db6da03103, type: 2}
   m_Color: {r: 0.08235294, g: 0.08235294, b: 0.08235294, a: 1}
   m_RaycastTarget: 1
@@ -5200,8 +5200,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e02fe3b58939a574a86bc7c36bfe4281, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   iconImage: {fileID: 964388210}
   rotateAngle: 5
   rotateDuration: 2
@@ -5219,8 +5219,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -5264,7 +5264,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -5316,8 +5316,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5454,8 +5454,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5591,8 +5591,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.16862746}
   m_RaycastTarget: 1
@@ -5666,8 +5666,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5723,8 +5723,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -5740,8 +5740,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -5843,8 +5843,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5918,8 +5918,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5994,8 +5994,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.96862745}
   m_RaycastTarget: 1
@@ -6051,8 +6051,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -6068,8 +6068,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -6171,8 +6171,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -6246,8 +6246,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.7647059}
   m_RaycastTarget: 1
@@ -6348,8 +6348,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
@@ -6378,8 +6378,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
@@ -6435,8 +6435,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -6513,8 +6513,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 9527febdf2ae1e449ab1eaf04a665ea7, type: 2}
   m_Color: {r: 0.058823526, g: 0.12827332, b: 0.24705882, a: 1}
   m_RaycastTarget: 1
@@ -6551,8 +6551,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -6648,8 +6648,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -6723,8 +6723,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7003,8 +7003,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c63021decd671d547a647e836ff3027f, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   aiCardUsageEnabled: 1
   aiCardHand: {fileID: 913000004}
   analysisDepth: 6
@@ -7034,8 +7034,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 04c29f31ef20e71469adc58e9542365f, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   startingCards:
   - {fileID: 3605416856650468344, guid: 6d91e8b65e8966c428f3b9843e37e07d, type: 3}
   - {fileID: 2175964123843911041, guid: 863300bbe4f485546955c80a16c13338, type: 3}
@@ -7048,6 +7048,15 @@ MonoBehaviour:
   - Assets/Prefab/Skill/SunsetBladeCard.prefab
   - Assets/Prefab/Skill/GiantCard.prefab
   - Assets/Prefab/Skill/FatherEnemyCard.prefab
+  useDeckRuntime: 1
+  deckConfigOverride: {fileID: 0}
+  useMapDeckConfig: 1
+  useAllSupportedCardsWhenDeckMissing: 1
+  fallbackInitialHandCount: 4
+  fallbackDrawIntervalTurns: 5
+  fallbackDrawCount: 1
+  fallbackReshuffleUsedPileWhenEmpty: 0
+  logDeckState: 0
 --- !u!1 &938165604
 GameObject:
   m_ObjectHideFlags: 0
@@ -7095,8 +7104,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7232,8 +7241,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7369,8 +7378,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7439,8 +7448,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 00fc18c285c515b49be499edca3e6a34, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1024790913
 GameObject:
   m_ObjectHideFlags: 0
@@ -8735,8 +8744,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8794,8 +8803,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -8811,8 +8820,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -8881,8 +8890,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 481f419e27766a34592756e3bae1fc43, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   content: {fileID: 232779361}
   spawnDelay: 0.2
 --- !u!114 &1036672680
@@ -8895,8 +8904,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0b484476f8e570240971d115f08b19d9, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   areaBounds: {fileID: 1422633468}
   overlap: 150
   cardY: 0
@@ -8960,8 +8969,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -8986,8 +8995,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c97afc556caea1c44969477eb7ddec74, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   ConformX: 1
   ConformY: 1
   Logging: 0
@@ -9039,8 +9048,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -9077,8 +9086,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -9120,7 +9129,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 8300000, guid: 472aa3d34b095fa468cc44b3fa88ae6e, type: 3}
@@ -9134,7 +9143,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -9168,8 +9177,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -9185,8 +9194,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -9289,8 +9298,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9435,8 +9444,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9503,8 +9512,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9541,8 +9550,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: -25.83, y: -40.92}
   m_UseGraphicAlpha: 1
@@ -9593,8 +9602,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9817,8 +9826,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 8f40f04e7bbbae348b09552d6ec016ab, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9855,8 +9864,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -9898,7 +9907,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -9912,7 +9921,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -9959,8 +9968,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -9976,8 +9985,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -10081,8 +10090,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -10119,8 +10128,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -10162,7 +10171,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -10176,7 +10185,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -10234,8 +10243,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 60830b44ee17d524e83e5bafa6b1a953, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1190515896
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10246,8 +10255,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -10263,8 +10272,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -10309,8 +10318,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2a1606145bb735d4287f436b46b74e3a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -10378,8 +10387,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -10500,8 +10509,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 60830b44ee17d524e83e5bafa6b1a953, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!225 &1232453033
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -10524,8 +10533,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7ffc11eba7a398d4a8fa73973471547e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -10544,8 +10553,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -10561,8 +10570,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -10664,8 +10673,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -10832,8 +10841,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.16862746}
   m_RaycastTarget: 1
@@ -10907,8 +10916,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -11027,8 +11036,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -11044,8 +11053,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -11110,8 +11119,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cf5fe2929a575ce43b3aee1356649818, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   turnColor: {fileID: 1136904361}
   whiteColor: {fileID: -4654731366540338491, guid: d6fbcf31613ca6f4592ed60618f8a4b9, type: 3}
   blackColor: {fileID: 1918842929224484825, guid: d6fbcf31613ca6f4592ed60618f8a4b9, type: 3}
@@ -11211,8 +11220,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -11348,8 +11357,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -11471,8 +11480,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 94af631dc2e524f4b906b5bd2f1aa678, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   promotionPanel: {fileID: 1190515899}
   timeReversalPanel: {fileID: 257632376}
   awakenPanel: {fileID: 1232453034}
@@ -11488,8 +11497,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1deb66d7a913f164698db9648985e943, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   ChessBoardTileMap: {fileID: 1024790916}
 --- !u!114 &1388470023
 MonoBehaviour:
@@ -11501,8 +11510,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 04edfc6ca84985143bf44d4dc27666a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   UIChessBoard: {fileID: 81987907}
   SelectTile: {fileID: 11400000, guid: 9523c4d553996d148a094f0f3aab6732, type: 2}
   MoveTile: {fileID: 11400000, guid: 62a53786bd4cc6c4db98665423525238, type: 2}
@@ -11520,8 +11529,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4ac18b6f187956544a39dae33ac45dcb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   FEN: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 '
   FENMapList:
   - FENChar: 112
@@ -11571,8 +11580,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cd3c1672c13a8ad4e98d5443fc409660, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   effectTilemap: {fileID: 891790250}
 --- !u!114 &1388470027
 MonoBehaviour:
@@ -11584,8 +11593,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f85221a7900618468e3ee16e5f36ab5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   PlayerColor: 0
   EnemyColor: 1
   BlackSprites:
@@ -11614,6 +11623,7 @@ MonoBehaviour:
   curTurn: 1
   IsGameInput: 1
   AiAutoMoveEnabled: 1
+  autoCreateAiCardController: 1
   aiTurnController: {fileID: 0}
 --- !u!1 &1388570847
 GameObject:
@@ -11666,8 +11676,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 16828e59bfb80334199b43bfd9f2d6c8, type: 2}
   m_Color: {r: 0.08176088, g: 0.08176088, b: 0.08176088, a: 1}
   m_RaycastTarget: 1
@@ -11748,8 +11758,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding: {x: 0, y: 0, z: 0, w: 0}
   m_Softness: {x: 0, y: 0}
 --- !u!114 &1409639190
@@ -11762,8 +11772,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 003ea7247916de143ab9d1db6da03103, type: 2}
   m_Color: {r: 0.08235294, g: 0.08235294, b: 0.08235294, a: 1}
   m_RaycastTarget: 1
@@ -11800,8 +11810,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e02fe3b58939a574a86bc7c36bfe4281, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   iconImage: {fileID: 1804697015}
   rotateAngle: 6
   rotateDuration: 1.8
@@ -11819,8 +11829,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -11864,7 +11874,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -11922,8 +11932,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12006,8 +12016,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: de8ed6541e822a64aad9a5aa093db648, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   contentPanel: {fileID: 3200000101}
   effectLayout: {fileID: 3200000104}
   cardPrefab: {fileID: 5188852121270727302, guid: 9800978b59d7e4e4f897dc10ae0d3a85, type: 3}
@@ -12070,8 +12080,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ee0da64e80e6fd240b41993587b76ada, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.3
   OnPanelEnabled:
@@ -12104,8 +12114,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c97afc556caea1c44969477eb7ddec74, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   ConformX: 1
   ConformY: 1
   Logging: 0
@@ -12176,8 +12186,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12313,8 +12323,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12388,8 +12398,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12463,8 +12473,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12602,8 +12612,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 8f40f04e7bbbae348b09552d6ec016ab, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12640,8 +12650,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -12683,7 +12693,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -12697,7 +12707,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -12749,8 +12759,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -12886,8 +12896,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.5882353}
   m_RaycastTarget: 1
@@ -12962,8 +12972,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
 --- !u!114 &1531565430
@@ -12976,8 +12986,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -13113,8 +13123,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -13253,8 +13263,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -13291,8 +13301,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f466259814a19b24aa6678fba237e654, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   titleText: {fileID: 1297219911}
 --- !u!1 &1559194562
 GameObject:
@@ -13341,8 +13351,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -13481,8 +13491,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -13519,8 +13529,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -13562,7 +13572,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -13576,7 +13586,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -13591,8 +13601,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 324fdd3ea78fab743bb1f3de9bc5898a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1571836332
 GameObject:
   m_ObjectHideFlags: 0
@@ -13624,8 +13634,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -13641,8 +13651,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -13707,8 +13717,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4030e2838e91dc646859eddbb6f8cda8, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   tilemap: {fileID: 1170031624}
   gameSelectTilemap: {fileID: 81987907}
   boardManager: {fileID: 1388470024}
@@ -13724,8 +13734,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 60830b44ee17d524e83e5bafa6b1a953, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1581804402
 GameObject:
   m_ObjectHideFlags: 0
@@ -13782,8 +13792,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 003ea7247916de143ab9d1db6da03103, type: 2}
   m_Color: {r: 0.17610055, g: 0.17610055, b: 0.17610055, a: 1}
   m_RaycastTarget: 1
@@ -13820,8 +13830,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding: {x: 0, y: 0, z: 0, w: 0}
   m_Softness: {x: 0, y: 0}
 --- !u!114 &1581804407
@@ -13834,8 +13844,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7448cbab472b81d4f84e335b37d8359a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   cards:
   - {fileID: 1150273814}
   - {fileID: 2046218173}
@@ -13860,8 +13870,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -13905,7 +13915,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -13937,8 +13947,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 58b4fb4d3ecf4de42986a62562f01bf2, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &1597619759
 Transform:
   m_ObjectHideFlags: 0
@@ -14016,8 +14026,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -14042,8 +14052,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 976aac20892c8c9438689c5d977bded1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   target: {fileID: 1598959955}
   duration: 0.4
   startOffsetX: 600
@@ -14065,8 +14075,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 1
@@ -14095,8 +14105,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -14140,7 +14150,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -14192,8 +14202,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -14332,8 +14342,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -14410,8 +14420,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -14455,7 +14465,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -14470,8 +14480,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
@@ -14545,8 +14555,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -14620,8 +14630,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -14805,8 +14815,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -14943,8 +14953,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.9019608}
   m_RaycastTarget: 1
@@ -14981,8 +14991,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -15026,7 +15036,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -15078,8 +15088,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -15155,8 +15165,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 8f40f04e7bbbae348b09552d6ec016ab, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15193,8 +15203,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -15236,7 +15246,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -15250,7 +15260,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -15304,8 +15314,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 8f40f04e7bbbae348b09552d6ec016ab, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15342,8 +15352,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -15385,7 +15395,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -15399,7 +15409,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -15452,8 +15462,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
 --- !u!114 &1784817162
@@ -15466,8 +15476,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15603,8 +15613,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15678,8 +15688,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15737,8 +15747,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -15754,8 +15764,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -15820,8 +15830,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 94eb88f2472d69647b09fda0d3acfd75, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   tilemap: {fileID: 1170031624}
   gameSelectTilemap: {fileID: 81987907}
   boardManager: {fileID: 1388470024}
@@ -15837,8 +15847,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59d07928d0040c844847e7a1ca8d1708, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   UIChessBoard: {fileID: 1170031624}
   SelectTile: {fileID: 11400000, guid: 9523c4d553996d148a094f0f3aab6732, type: 2}
 --- !u!1 &1804697013
@@ -15888,8 +15898,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -15963,8 +15973,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -16123,8 +16133,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2a2e019105c4f4f46b1f50a0e74df947, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   canvasGroup: {fileID: 1811811514}
   messageText: {fileID: 100791569}
   fadeDuration: 0.2
@@ -16139,8 +16149,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c97afc556caea1c44969477eb7ddec74, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   ConformX: 1
   ConformY: 1
   Logging: 0
@@ -16202,8 +16212,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -16265,8 +16275,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -16341,8 +16351,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: -34.7, y: -45.5}
   m_UseGraphicAlpha: 1
@@ -16356,8 +16366,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -16416,8 +16426,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 60830b44ee17d524e83e5bafa6b1a953, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!225 &1860162445
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -16440,8 +16450,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -16457,8 +16467,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -16524,8 +16534,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d3fe92fa420a91449ee247e32b58921, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   baseEnabled: 0
   fadeDuration: 0.2
   OnPanelEnabled:
@@ -16584,8 +16594,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -16661,8 +16671,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -16704,7 +16714,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 0}
@@ -16718,7 +16728,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -16733,8 +16743,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.25471687, b: 0.25471687, a: 1}
   m_RaycastTarget: 1
@@ -16808,8 +16818,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -16878,8 +16888,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9c348ec35ec64034fb16e3079b555922, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   cardHandLayout: {fileID: 1036672680}
   arenaBG: {fileID: 1174044515}
 --- !u!1 &1933265168
@@ -16929,8 +16939,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -17046,8 +17056,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c1dd5181de99be443ae8f7486fcfff39, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   cardRandomizer: {fileID: 1036672679}
   _cardPool: []
   _buffs: []
@@ -17113,8 +17123,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -17250,8 +17260,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.9137255}
   m_RaycastTarget: 1
@@ -22170,8 +22180,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -22233,8 +22243,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -22309,8 +22319,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -22347,8 +22357,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_EffectDistance: {x: 38.6, y: -35.06}
   m_UseGraphicAlpha: 1
@@ -22399,8 +22409,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -22474,8 +22484,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -22611,8 +22621,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -22748,8 +22758,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.16862746}
   m_RaycastTarget: 1
@@ -22824,8 +22834,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
 --- !u!114 &2117033551
@@ -22838,8 +22848,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -22981,8 +22991,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.05882353, g: 0.05882353, b: 0.05882353, a: 1}
   m_RaycastTarget: 1
@@ -23057,8 +23067,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.5372549}
   m_RaycastTarget: 1
@@ -23133,8 +23143,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -23281,8 +23291,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.04, g: 0.045, b: 0.05, a: 0}
   m_RaycastTarget: 1
@@ -23311,8 +23321,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 30
     m_Right: 30
@@ -23337,8 +23347,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa677fe4b4e77e41aaed25b343ed467, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -23380,7 +23390,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument:
+          m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
   clickSound: {fileID: 8300000, guid: 10c1ce1260803ab4e961c1894ff2ab2d, type: 3}
@@ -23394,7 +23404,7 @@ MonoBehaviour:
   uIAnimationObject: {fileID: 0}
   isStartAnimation: 0
   isEndAnimation: 0
-  nextSceneName:
+  nextSceneName: 
   practiceSceneName: MainGameScene
   rewardSceneName: RewardScene
   resultSceneName: ResultScene
@@ -23409,8 +23419,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 2
 --- !u!1 &3200000200
@@ -23521,8 +23531,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 16828e59bfb80334199b43bfd9f2d6c8, type: 2}
   m_Color: {r: 0.08235294, g: 0.08235294, b: 0.08235294, a: 1}
   m_RaycastTarget: 0
@@ -23551,8 +23561,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8b8e5af207de4bc99a41c6c46d258fd7, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   statusRoot: {fileID: 3200000301}
   labelText: {fileID: 3200000343}
 --- !u!1 &3200000340
@@ -23610,8 +23620,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -23706,7 +23716,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 614858718348752985, guid: e79c0536680dbac4a9b14b3dfee70bc8, type: 3}
       propertyPath: m_Camera
-      value:
+      value: 
       objectReference: {fileID: 14408963}
     - target: {fileID: 855461029295654953, guid: e79c0536680dbac4a9b14b3dfee70bc8, type: 3}
       propertyPath: m_IsActive
@@ -23910,7 +23920,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6725642127812877614, guid: e79c0536680dbac4a9b14b3dfee70bc8, type: 3}
       propertyPath: targetUI
-      value:
+      value: 
       objectReference: {fileID: 2598052484459980065}
     - target: {fileID: 6834847371578655326, guid: e79c0536680dbac4a9b14b3dfee70bc8, type: 3}
       propertyPath: m_AnchorMax.y
@@ -23974,8 +23984,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b9506e1705d13bc4dac603f4316b26bd, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutionResult.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutionResult.cs
@@ -13,6 +13,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
         MissingExecutor,
         UnsupportedCardType,
         TargetUnavailable,
+        CardUseBlocked,
         ExecutionFailed
     }
 

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardExecutor.cs
@@ -1,6 +1,7 @@
 using System;
 using ChaosChess.AI.Decision;
 using ChaosChess.AI.Domain;
+using ChaosChess.Unity.AIIntegration.Mapping;
 using UnityEngine;
 using AiPieceColor = ChaosChess.AI.Domain.PieceColor;
 
@@ -86,6 +87,22 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                     recommendation);
             }
 
+            global::CardDataSO cardSO = GetCardDataSO(cardObject);
+            if (!global::CardUseRules.CanUseForAi(
+                    global::GameManager.Instance,
+                    UnityAiColorMapper.ToUnityColor(actor),
+                    cardSO,
+                    requireCardInHand: true,
+                    containsCard: aiCardHand.Contains,
+                    out global::CardBlockReason blockReason))
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.CardUseBlocked,
+                    $"Card use blocked by shared rules: {blockReason}.",
+                    recommendation,
+                    cardSO);
+            }
+
             AiCardTargetPlan plan;
             AiCardExecutionStatus failureStatus;
             string reason;
@@ -152,6 +169,22 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                     $"AI hand does not contain card id '{usePlan.CardId}'.");
             }
 
+            global::CardDataSO cardSO = GetCardDataSO(cardObject);
+            if (!global::CardUseRules.CanUseForAi(
+                    global::GameManager.Instance,
+                    UnityAiColorMapper.ToUnityColor(actor),
+                    cardSO,
+                    requireCardInHand: true,
+                    containsCard: aiCardHand.Contains,
+                    out global::CardBlockReason blockReason))
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.CardUseBlocked,
+                    $"Card use blocked by shared rules: {blockReason}.",
+                    recommendation: null,
+                    cardSO: cardSO);
+            }
+
             if (!targetPlanner.TryCreatePlan(
                     usePlan,
                     cardObject,
@@ -201,6 +234,22 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                 return AiCardExecutionResult.Failure(
                     AiCardExecutionStatus.CardNotInHand,
                     $"AI hand does not contain card id '{cardId}'.");
+            }
+
+            global::CardDataSO cardSO = GetCardDataSO(cardObject);
+            if (!global::CardUseRules.CanUseForAi(
+                    global::GameManager.Instance,
+                    UnityAiColorMapper.ToUnityColor(actor),
+                    cardSO,
+                    requireCardInHand: true,
+                    containsCard: aiCardHand.Contains,
+                    out global::CardBlockReason blockReason))
+            {
+                return AiCardExecutionResult.Failure(
+                    AiCardExecutionStatus.CardUseBlocked,
+                    $"Card use blocked by shared rules: {blockReason}.",
+                    recommendation: null,
+                    cardSO: cardSO);
             }
 
             if (!targetPlanner.TryCreatePlan(

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardHand.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Cards/AiCardHand.cs
@@ -4,6 +4,235 @@ using UnityEngine;
 
 namespace ChaosChess.Unity.AIIntegration.Cards
 {
+    [CreateAssetMenu(fileName = "AI Deck Config", menuName = "AI/AI Deck Config")]
+    public sealed class AiDeckConfig : ScriptableObject
+    {
+        [Serializable]
+        public sealed class CardEntry
+        {
+            public GameObject CardPrefab;
+            [Min(1)] public int Count = 1;
+        }
+
+        [SerializeField] private string deckId;
+        [SerializeField] private List<CardEntry> cards = new();
+        [SerializeField, Min(0)] private int initialHandCount = AiCardHand.MaxCards;
+        [SerializeField, Min(1)] private int drawIntervalTurns = 5;
+        [SerializeField, Min(0)] private int drawCount = 1;
+        [SerializeField, Range(1, AiCardHand.MaxCards)] private int maxHandCount = AiCardHand.MaxCards;
+        [SerializeField, Min(0)] private int remainingUsesPerCard = 1;
+        [SerializeField] private bool reshuffleUsedPileWhenEmpty;
+
+        public string DeckId => string.IsNullOrWhiteSpace(deckId) ? name : deckId;
+        public IReadOnlyList<CardEntry> Cards => cards;
+        public int InitialHandCount => Mathf.Clamp(initialHandCount, 0, MaxHandCount);
+        public int DrawIntervalTurns => Mathf.Max(1, drawIntervalTurns);
+        public int DrawCount => Mathf.Max(0, drawCount);
+        public int MaxHandCount => Mathf.Clamp(maxHandCount, 1, AiCardHand.MaxCards);
+        public int RemainingUsesPerCard => Mathf.Max(0, remainingUsesPerCard);
+        public bool ReshuffleUsedPileWhenEmpty => reshuffleUsedPileWhenEmpty;
+
+        private void OnValidate()
+        {
+            initialHandCount = Mathf.Max(0, initialHandCount);
+            drawIntervalTurns = Mathf.Max(1, drawIntervalTurns);
+            drawCount = Mathf.Max(0, drawCount);
+            maxHandCount = Mathf.Clamp(maxHandCount, 1, AiCardHand.MaxCards);
+            remainingUsesPerCard = Mathf.Max(0, remainingUsesPerCard);
+
+            if (cards == null)
+                cards = new List<CardEntry>();
+
+            foreach (CardEntry entry in cards)
+            {
+                if (entry != null)
+                    entry.Count = Mathf.Max(1, entry.Count);
+            }
+        }
+    }
+
+    public sealed class AiDeckRuntime
+    {
+        private readonly List<GameObject> drawPile = new();
+        private readonly List<GameObject> usedPile = new();
+        private AiDeckConfig config;
+        private bool runtimeConfigured;
+        private int runtimeDrawIntervalTurns;
+        private int runtimeDrawCount;
+        private int runtimeMaxHandCount;
+        private int runtimeRemainingUsesPerCard;
+        private bool runtimeReshuffleUsedPileWhenEmpty;
+        private int turnsSinceLastDraw;
+
+        public bool IsConfigured => config != null || runtimeConfigured;
+        public int DrawPileCount => drawPile.Count;
+        public int UsedPileCount => usedPile.Count;
+        public int RemainingUsesPerCard => config != null ? config.RemainingUsesPerCard : runtimeRemainingUsesPerCard;
+        private int DrawIntervalTurns => config != null ? config.DrawIntervalTurns : runtimeDrawIntervalTurns;
+        private int DrawCount => config != null ? config.DrawCount : runtimeDrawCount;
+        private int MaxHandCount => config != null ? config.MaxHandCount : runtimeMaxHandCount;
+        private bool ReshuffleUsedPileWhenEmpty => config != null ? config.ReshuffleUsedPileWhenEmpty : runtimeReshuffleUsedPileWhenEmpty;
+
+        public void Initialize(AiDeckConfig deckConfig, List<GameObject> hand)
+        {
+            config = deckConfig;
+            runtimeConfigured = false;
+            turnsSinceLastDraw = 0;
+            drawPile.Clear();
+            usedPile.Clear();
+            hand?.Clear();
+
+            if (config == null)
+                return;
+
+            foreach (AiDeckConfig.CardEntry entry in config.Cards)
+            {
+                if (entry == null || entry.CardPrefab == null)
+                    continue;
+
+                int count = Mathf.Max(1, entry.Count);
+                for (int i = 0; i < count; i++)
+                    drawPile.Add(entry.CardPrefab);
+            }
+
+            Shuffle(drawPile);
+            DrawCards(hand, config.InitialHandCount);
+        }
+
+        public void InitializeRuntimeDeck(
+            IEnumerable<GameObject> cards,
+            List<GameObject> hand,
+            int initialHandCount,
+            int drawIntervalTurns,
+            int drawCount,
+            int maxHandCount,
+            int remainingUsesPerCard,
+            bool reshuffleUsedPileWhenEmpty)
+        {
+            config = null;
+            runtimeConfigured = true;
+            runtimeDrawIntervalTurns = Mathf.Max(1, drawIntervalTurns);
+            runtimeDrawCount = Mathf.Max(0, drawCount);
+            runtimeMaxHandCount = Mathf.Clamp(maxHandCount, 1, AiCardHand.MaxCards);
+            runtimeRemainingUsesPerCard = Mathf.Max(0, remainingUsesPerCard);
+            runtimeReshuffleUsedPileWhenEmpty = reshuffleUsedPileWhenEmpty;
+            turnsSinceLastDraw = 0;
+            drawPile.Clear();
+            usedPile.Clear();
+            hand?.Clear();
+
+            if (cards != null)
+            {
+                foreach (GameObject card in cards)
+                {
+                    if (card != null)
+                        drawPile.Add(card);
+                }
+            }
+
+            Shuffle(drawPile);
+            DrawCards(hand, Mathf.Clamp(initialHandCount, 0, runtimeMaxHandCount));
+        }
+
+        public int HandleAiTurnStarted(List<GameObject> hand)
+        {
+            if (!IsConfigured)
+                return 0;
+
+            turnsSinceLastDraw++;
+            if (turnsSinceLastDraw < DrawIntervalTurns)
+                return 0;
+
+            if (hand != null && hand.Count >= MaxHandCount)
+                return 0;
+
+            int drawn = DrawCards(hand, DrawCount);
+            if (drawn > 0)
+                turnsSinceLastDraw = 0;
+
+            return drawn;
+        }
+
+        public void RecordUsedCard(GameObject cardPrefab)
+        {
+            if (!IsConfigured || cardPrefab == null)
+                return;
+
+            usedPile.Add(cardPrefab);
+        }
+
+        private int DrawCards(List<GameObject> hand, int count)
+        {
+            if (!IsConfigured || hand == null || count <= 0)
+                return 0;
+
+            int drawn = 0;
+            int attempts = 0;
+            int maxAttempts = Mathf.Max(8, drawPile.Count + usedPile.Count + count + 8);
+            var skippedDuplicates = new List<GameObject>();
+
+            while (drawn < count && hand.Count < MaxHandCount && attempts < maxAttempts)
+            {
+                attempts++;
+
+                if (!TryDrawOne(out GameObject card))
+                    break;
+
+                if (AiCardHand.ContainsSameCard(hand, card))
+                {
+                    skippedDuplicates.Add(card);
+                    continue;
+                }
+
+                hand.Add(card);
+                drawn++;
+            }
+
+            if (skippedDuplicates.Count > 0)
+            {
+                drawPile.AddRange(skippedDuplicates);
+                Shuffle(drawPile);
+            }
+
+            return drawn;
+        }
+
+        private bool TryDrawOne(out GameObject card)
+        {
+            card = null;
+
+            if (drawPile.Count == 0 && ReshuffleUsedPileWhenEmpty && usedPile.Count > 0)
+            {
+                drawPile.AddRange(usedPile);
+                usedPile.Clear();
+                Shuffle(drawPile);
+            }
+
+            while (drawPile.Count > 0)
+            {
+                int lastIndex = drawPile.Count - 1;
+                card = drawPile[lastIndex];
+                drawPile.RemoveAt(lastIndex);
+                if (card != null)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static void Shuffle(List<GameObject> cards)
+        {
+            if (cards == null)
+                return;
+
+            for (int i = cards.Count - 1; i > 0; i--)
+            {
+                int j = UnityEngine.Random.Range(0, i + 1);
+                (cards[i], cards[j]) = (cards[j], cards[i]);
+            }
+        }
+    }
+
     public sealed class AiCardHand : MonoBehaviour
     {
         public const int MaxCards = 4;
@@ -12,14 +241,33 @@ namespace ChaosChess.Unity.AIIntegration.Cards
         [SerializeField] private int defaultRemainingUses = 1;
         [SerializeField] private bool useEditorConfiguredStartingCards;
         [SerializeField] private List<string> editorStartingCardPrefabPaths = new();
+        [SerializeField] private bool useDeckRuntime = true;
+        [SerializeField] private AiDeckConfig deckConfigOverride;
+        [SerializeField] private bool useMapDeckConfig = true;
+        [SerializeField] private bool useAllSupportedCardsWhenDeckMissing = true;
+        [SerializeField, Min(0)] private int fallbackInitialHandCount = MaxCards;
+        [SerializeField, Min(1)] private int fallbackDrawIntervalTurns = 5;
+        [SerializeField, Min(0)] private int fallbackDrawCount = 1;
+        [SerializeField] private bool fallbackReshuffleUsedPileWhenEmpty;
+        [SerializeField] private bool logDeckState;
 
         private readonly List<GameObject> runtimeCards = new();
+        private readonly AiDeckRuntime deckRuntime = new();
         private bool runtimeCardsInitialized;
+        private bool deckRuntimeInitialized;
+        private bool debugHandOverrideActive;
+        private string activeDeckId;
+        private int lastHandledAiTurn = -1;
         private int version;
 
         public IReadOnlyList<GameObject> AvailableCards => CurrentCards;
-        public int DefaultRemainingUses => Mathf.Max(0, defaultRemainingUses);
+        public int DefaultRemainingUses => deckRuntimeInitialized && deckRuntime.IsConfigured
+            ? deckRuntime.RemainingUsesPerCard
+            : Mathf.Max(0, defaultRemainingUses);
         public int Version => version;
+        public string ActiveDeckId => activeDeckId;
+        public int DrawPileCount => deckRuntimeInitialized && deckRuntime.IsConfigured ? deckRuntime.DrawPileCount : 0;
+        public int UsedPileCount => deckRuntimeInitialized && deckRuntime.IsConfigured ? deckRuntime.UsedPileCount : 0;
         public static event Action<AiCardHand> AnyChanged;
         public event Action Changed;
 
@@ -109,12 +357,60 @@ namespace ChaosChess.Unity.AIIntegration.Cards
             }
 
             runtimeCardsInitialized = true;
+            debugHandOverrideActive = true;
+            deckRuntimeInitialized = false;
+            activeDeckId = null;
             NotifyChanged();
+        }
+
+        public void ClearDebugHandOverride()
+        {
+            if (!debugHandOverrideActive)
+                return;
+
+            debugHandOverrideActive = false;
+            deckRuntimeInitialized = false;
+            RebuildRuntimeCardsFromConfiguration();
+        }
+
+        public void PrepareForAiTurn(global::GameManager gameManager)
+        {
+            if (gameManager == null)
+                return;
+
+            if (lastHandledAiTurn == gameManager.CurrentTurn)
+                return;
+
+            lastHandledAiTurn = gameManager.CurrentTurn;
+
+            if (!ShouldUseDeckRuntime())
+                return;
+
+            AiDeckConfig config = ResolveDeckConfig();
+            if (config == null && !TryEnsureFallbackRuntimeDeck())
+                return;
+
+            if (config != null)
+                EnsureDeckRuntime(config);
+
+            int drawn = deckRuntime.HandleAiTurnStarted(runtimeCards);
+            if (drawn > 0)
+                NotifyChanged();
+
+            if (logDeckState)
+            {
+                Debug.Log(
+                    $"[AI Deck] turn={gameManager.CurrentTurn}, deck={activeDeckId}, hand={runtimeCards.Count}, " +
+                    $"drawn={drawn}, drawPile={deckRuntime.DrawPileCount}, usedPile={deckRuntime.UsedPileCount}.");
+            }
         }
 
         private void OnValidate()
         {
             defaultRemainingUses = Mathf.Max(0, defaultRemainingUses);
+            fallbackInitialHandCount = Mathf.Clamp(fallbackInitialHandCount, 0, MaxCards);
+            fallbackDrawIntervalTurns = Mathf.Max(1, fallbackDrawIntervalTurns);
+            fallbackDrawCount = Mathf.Max(0, fallbackDrawCount);
             TrimStartingCards();
         }
 
@@ -181,6 +477,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                     continue;
 
                 cards.RemoveAt(i);
+                RecordUsedCard(cardPrefab);
                 NotifyChanged();
                 return true;
             }
@@ -212,6 +509,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
                 }
 
                 cards.RemoveAt(i);
+                RecordUsedCard(cardPrefab);
                 NotifyChanged();
                 return true;
             }
@@ -305,7 +603,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
             return true;
         }
 
-        private static bool ContainsSameCard(IEnumerable<GameObject> cards, GameObject card)
+        public static bool ContainsSameCard(IEnumerable<GameObject> cards, GameObject card)
         {
             if (cards == null || card == null)
                 return false;
@@ -319,7 +617,7 @@ namespace ChaosChess.Unity.AIIntegration.Cards
             return false;
         }
 
-        private static bool IsSameCard(GameObject a, GameObject b)
+        public static bool IsSameCard(GameObject a, GameObject b)
         {
             if (a == null || b == null)
                 return false;
@@ -340,6 +638,147 @@ namespace ChaosChess.Unity.AIIntegration.Cards
 
             return !string.IsNullOrWhiteSpace(aSO.AiCardId)
                 && string.Equals(aSO.AiCardId, bSO.AiCardId, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        private bool ShouldUseDeckRuntime()
+        {
+            return Application.isPlaying &&
+                useDeckRuntime &&
+                !debugHandOverrideActive &&
+                !useEditorConfiguredStartingCards;
+        }
+
+        private AiDeckConfig ResolveDeckConfig()
+        {
+            if (deckConfigOverride != null)
+                return deckConfigOverride;
+
+            if (!useMapDeckConfig)
+                return null;
+
+            global::MapManager mapManager = global::MapManager.Instance;
+            return mapManager != null ? mapManager.ResolveAiDeckConfig(mapManager.curMap) : null;
+        }
+
+        private void EnsureDeckRuntime(AiDeckConfig config)
+        {
+            string deckId = config != null ? config.DeckId : null;
+            if (deckRuntimeInitialized && string.Equals(activeDeckId, deckId, StringComparison.Ordinal))
+                return;
+
+            runtimeCards.Clear();
+            deckRuntime.Initialize(config, runtimeCards);
+            runtimeCardsInitialized = true;
+            deckRuntimeInitialized = config != null;
+            activeDeckId = deckId;
+            NotifyChanged();
+
+            if (logDeckState && config != null)
+            {
+                Debug.Log(
+                    $"[AI Deck] initialized deck={activeDeckId}, hand={runtimeCards.Count}, " +
+                    $"drawPile={deckRuntime.DrawPileCount}, usedPile={deckRuntime.UsedPileCount}.");
+            }
+        }
+
+        private bool TryEnsureFallbackRuntimeDeck()
+        {
+            if (!useAllSupportedCardsWhenDeckMissing)
+                return false;
+
+            string fallbackDeckId = ResolveFallbackRuntimeDeckId();
+            if (deckRuntimeInitialized && string.Equals(activeDeckId, fallbackDeckId, StringComparison.Ordinal))
+                return true;
+
+            List<GameObject> fallbackCards = ResolveFallbackRuntimeDeckCards();
+            if (fallbackCards.Count == 0)
+                return false;
+
+            runtimeCards.Clear();
+            deckRuntime.InitializeRuntimeDeck(
+                fallbackCards,
+                runtimeCards,
+                fallbackInitialHandCount,
+                fallbackDrawIntervalTurns,
+                fallbackDrawCount,
+                MaxCards,
+                defaultRemainingUses,
+                fallbackReshuffleUsedPileWhenEmpty);
+            runtimeCardsInitialized = true;
+            deckRuntimeInitialized = true;
+            activeDeckId = fallbackDeckId;
+            NotifyChanged();
+
+            if (logDeckState)
+            {
+                Debug.Log(
+                    $"[AI Deck] initialized fallback deck={activeDeckId}, hand={runtimeCards.Count}, " +
+                    $"drawPile={deckRuntime.DrawPileCount}, usedPile={deckRuntime.UsedPileCount}.");
+            }
+
+            return true;
+        }
+
+        private static string ResolveFallbackRuntimeDeckId()
+        {
+            global::MapManager mapManager = global::MapManager.Instance;
+            if (mapManager != null && mapManager.curMap != null)
+                return mapManager.GetRuntimeDeckKey(mapManager.curMap);
+
+            return "runtime_all_supported_cards";
+        }
+
+        private static List<GameObject> ResolveFallbackRuntimeDeckCards()
+        {
+            global::MapManager mapManager = global::MapManager.Instance;
+            if (mapManager != null && mapManager.curMap != null)
+            {
+                var nodeCards = new List<GameObject>();
+                foreach (GameObject card in mapManager.ResolveAiRuntimeDeckCards(mapManager.curMap))
+                {
+                    if (card != null && !ContainsSameCard(nodeCards, card))
+                        nodeCards.Add(card);
+                }
+
+                if (nodeCards.Count > 0)
+                    return nodeCards;
+            }
+
+            return BuildAllSupportedCardPool();
+        }
+
+        private static List<GameObject> BuildAllSupportedCardPool()
+        {
+            var cards = new List<GameObject>();
+            global::CardRandomizerManager manager = global::CardRandomizerManager.Instance;
+            if (manager == null || manager.AllCards == null)
+                return cards;
+
+            foreach (GameObject cardPrefab in manager.AllCards)
+            {
+                global::CardData cardData = cardPrefab != null
+                    ? cardPrefab.GetComponent<global::CardData>()
+                    : null;
+                global::CardDataSO dataSO = cardData != null ? cardData.DataSO : null;
+
+                if (dataSO == null ||
+                    !dataSO.AiSupported ||
+                    string.IsNullOrWhiteSpace(dataSO.AiCardId) ||
+                    dataSO.AiCategory == global::AiCardCategory.Unknown)
+                {
+                    continue;
+                }
+
+                cards.Add(cardPrefab);
+            }
+
+            return cards;
+        }
+
+        private void RecordUsedCard(GameObject cardPrefab)
+        {
+            if (deckRuntimeInitialized)
+                deckRuntime.RecordUsedCard(cardPrefab);
         }
     }
 }

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Mapping/UnityAiColorMapper.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Mapping/UnityAiColorMapper.cs
@@ -10,5 +10,12 @@ namespace ChaosChess.Unity.AIIntegration.Mapping
                 ? AiPieceColor.White
                 : AiPieceColor.Black;
         }
+
+        public static global::PieceColor ToUnityColor(AiPieceColor color)
+        {
+            return color == AiPieceColor.White
+                ? global::PieceColor.White
+                : global::PieceColor.Black;
+        }
     }
 }

--- a/ChaosChess_v2/Assets/Script/AIIntegration/Runtime/AiTurnController.cs
+++ b/ChaosChess_v2/Assets/Script/AIIntegration/Runtime/AiTurnController.cs
@@ -87,13 +87,27 @@ namespace ChaosChess.Unity.AIIntegration.Runtime
             if (gameManager == null || boardManager == null)
                 return false;
 
+            AiCardHand hand = ResolveCardHand();
+            hand?.PrepareForAiTurn(gameManager);
+
+            if (!global::CardUseRules.CanUseForAi(
+                    gameManager,
+                    gameManager.turnColor,
+                    cardSO: null,
+                    requireCardInHand: false,
+                    containsCard: null,
+                    out global::CardBlockReason blockReason))
+            {
+                Debug.Log($"[AI Turn] Card planning skipped: {blockReason}.");
+                return false;
+            }
+
             if (isRequestRunning)
             {
                 Debug.LogWarning("[AI Turn] Ignored duplicate AI turn request while card analysis is running.");
                 return true;
             }
 
-            AiCardHand hand = ResolveCardHand();
             if (hand == null || hand.AvailableCards == null || hand.AvailableCards.Count == 0)
                 return false;
 

--- a/ChaosChess_v2/Assets/Script/Card/CardBlockNotifier.cs
+++ b/ChaosChess_v2/Assets/Script/Card/CardBlockNotifier.cs
@@ -3,13 +3,18 @@ using UnityEngine;
 /// <summary>카드를 사용할 수 없는 사유.</summary>
 public enum CardBlockReason
 {
+    None,
     NoTargetPiece,        // 조건에 맞는 대상 기물이 없음
     AllPiecesAffected,    // 대상 기물에 이미 모든 효과가 적용됨
     NoSelectableTile,     // 카드를 놓을 빈 칸이 없음
     SelectionInProgress,  // 다른 카드 선택이 진행 중
     PlayerInCheck,        // 플레이어가 체크 상태
+    InCheck,              // 현재 카드 사용자 진영이 체크 상태
     NotPlayerTurn,        // 플레이어 턴이 아님
     ArenaInProgress,      // 투기장 진행 중
+    GameEnded,            // 게임이 종료됨
+    MissingCardData,      // 카드 데이터가 없음
+    CardNotInHand,        // 손패에 없는 카드
 }
 
 /// <summary>
@@ -30,7 +35,10 @@ public static class CardBlockNotifier
     {
         GameManager gm = GameManager.Instance;
         if (gm == null) return CardBlockReason.NotPlayerTurn;
+        if (gm.IsEndGame || gm.FinishType != GameResult.None) return CardBlockReason.GameEnded;
         if (gm.IsArenaMode) return CardBlockReason.ArenaInProgress;
+        if (CardSelectionState.IsLocked) return CardBlockReason.SelectionInProgress;
+        if (!gm.IsPlayerTurn) return CardBlockReason.NotPlayerTurn;
         if (gm.IsPlayerInCheck) return CardBlockReason.PlayerInCheck;
         return CardBlockReason.NotPlayerTurn;
     }
@@ -50,13 +58,108 @@ public static class CardBlockNotifier
             case CardBlockReason.SelectionInProgress:
                 return "다른 카드를 사용하는 중입니다.";
             case CardBlockReason.PlayerInCheck:
+            case CardBlockReason.InCheck:
                 return "체크 상태에서는 카드를 사용할 수 없습니다.";
             case CardBlockReason.NotPlayerTurn:
                 return "상대 턴에는 카드를 사용할 수 없습니다.";
             case CardBlockReason.ArenaInProgress:
                 return "투기장 진행 중에는 카드를 사용할 수 없습니다.";
+            case CardBlockReason.GameEnded:
+                return "게임이 종료되어 카드를 사용할 수 없습니다.";
+            case CardBlockReason.MissingCardData:
+                return "카드 데이터가 없어 사용할 수 없습니다.";
+            case CardBlockReason.CardNotInHand:
+                return "손패에 없는 카드는 사용할 수 없습니다.";
             default:
                 return "카드를 사용할 수 없습니다.";
         }
+    }
+}
+
+public enum CardUseActor
+{
+    Player,
+    AI
+}
+
+public static class CardUseRules
+{
+    public static bool CanUseForCurrentPlayer(CardDataSO cardSO, bool requireCardInHand, System.Func<CardDataSO, bool> containsCard, out CardBlockReason reason)
+    {
+        GameManager gameManager = GameManager.Instance;
+        return CanUse(gameManager, gameManager != null ? gameManager.PlayerColor : PieceColor.White, CardUseActor.Player, cardSO, requireCardInHand, containsCard, out reason);
+    }
+
+    public static bool CanUseForAi(GameManager gameManager, PieceColor actorColor, CardDataSO cardSO, bool requireCardInHand, System.Func<CardDataSO, bool> containsCard, out CardBlockReason reason)
+    {
+        return CanUse(gameManager, actorColor, CardUseActor.AI, cardSO, requireCardInHand, containsCard, out reason);
+    }
+
+    public static bool CanUse(
+        GameManager gameManager,
+        PieceColor actorColor,
+        CardUseActor actor,
+        CardDataSO cardSO,
+        bool requireCardInHand,
+        System.Func<CardDataSO, bool> containsCard,
+        out CardBlockReason reason)
+    {
+        reason = CardBlockReason.None;
+
+        if (gameManager == null)
+        {
+            reason = CardBlockReason.NotPlayerTurn;
+            return false;
+        }
+
+        if (gameManager.IsEndGame || gameManager.FinishType != GameResult.None)
+        {
+            reason = CardBlockReason.GameEnded;
+            return false;
+        }
+
+        if (gameManager.IsArenaMode)
+        {
+            reason = CardBlockReason.ArenaInProgress;
+            return false;
+        }
+
+        if (gameManager.turnColor != actorColor)
+        {
+            reason = CardBlockReason.NotPlayerTurn;
+            return false;
+        }
+
+        if (actor == CardUseActor.Player && CardSelectionState.IsLocked)
+        {
+            reason = CardBlockReason.SelectionInProgress;
+            return false;
+        }
+
+        if (actor == CardUseActor.Player && gameManager.IsPlayerInCheck)
+        {
+            reason = CardBlockReason.InCheck;
+            return false;
+        }
+
+        if (actor == CardUseActor.AI && gameManager.IsCurrentTurnInCheck)
+        {
+            reason = CardBlockReason.InCheck;
+            return false;
+        }
+
+        if (cardSO == null && requireCardInHand)
+        {
+            reason = CardBlockReason.MissingCardData;
+            return false;
+        }
+
+        if (cardSO != null && requireCardInHand && (containsCard == null || !containsCard(cardSO)))
+        {
+            reason = CardBlockReason.CardNotInHand;
+            return false;
+        }
+
+        return true;
     }
 }

--- a/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
+++ b/ChaosChess_v2/Assets/Script/ChessSystem/GameManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using ChaosChess.Unity.AIIntegration.Cards;
 using ChaosChess.Unity.AIIntegration.Runtime;
 using UnityEngine;
 using DG.Tweening;
@@ -35,10 +36,13 @@ public class GameManager : MonoBehaviour
     [SerializeField] private int curTurn;
     public bool IsPlayerTurn => (curTurn % 2 == 1);
     public bool IsPlayerInCheck { get; private set; }
+    public bool IsCurrentTurnInCheck { get; private set; }
+    public int CurrentTurn => curTurn;
 
     public bool IsGameInput = true;
     /// <summary>false이면 RequestAIMove가 무시됩니다. 카드 이펙트 랩에서 양쪽을 수동으로 두기 위해 사용합니다.</summary>
     public bool AiAutoMoveEnabled = true;
+    [SerializeField] private bool autoCreateAiCardController = true;
     [SerializeField] private AiTurnController aiTurnController;
     public bool IsEndGame { get; private set; } = false;
     public bool IsArenaMode { get; set; } = false;
@@ -118,6 +122,7 @@ public class GameManager : MonoBehaviour
         aiTurnController = aiTurnController != null
             ? aiTurnController
             : FindFirstObjectByType<AiTurnController>();
+        EnsureAiCardController();
 
         FinishType = GameResult.None;
 
@@ -650,6 +655,8 @@ public class GameManager : MonoBehaviour
             return;
         }
 
+        EnsureAiCardController();
+
         if (aiTurnController != null &&
             aiTurnController.TryRequestTurn(this, BoardManager.Instance, RequestStockfishAIMove))
         {
@@ -657,6 +664,22 @@ public class GameManager : MonoBehaviour
         }
 
         RequestStockfishAIMove();
+    }
+
+    private void EnsureAiCardController()
+    {
+        if (!autoCreateAiCardController)
+            return;
+
+        AiCardHand hand = FindFirstObjectByType<AiCardHand>();
+        if (hand == null)
+        {
+            GameObject systemObject = new GameObject("AI Card System (Runtime)");
+            hand = systemObject.AddComponent<AiCardHand>();
+        }
+
+        if (aiTurnController == null)
+            aiTurnController = hand.gameObject.AddComponent<AiTurnController>();
     }
 
     private void RequestStockfishAIMove()
@@ -833,12 +856,14 @@ public class GameManager : MonoBehaviour
                 ArenaManager.Instance.EndArena(ArenaResult.OpponentCheckmated);
                 ResetActions();
             }
+            IsCurrentTurnInCheck = false;
             UpdatePlayerCheckState(false);
             return;
         }
 
         if (FinishType != GameResult.None)
         {
+            IsCurrentTurnInCheck = false;
             UpdatePlayerCheckState(false);
             return;
         }
@@ -851,6 +876,7 @@ public class GameManager : MonoBehaviour
             FinishType = GameResult.Draw;
         }
         bool isCheck = FairyStockfishBridge.Instance.IsInCheck();
+        IsCurrentTurnInCheck = isCheck;
         UpdatePlayerCheckState(IsPlayerTurn && isCheck);
 
         if (cancelCurrentGameStateEvaluation)

--- a/ChaosChess_v2/Assets/Script/Map/Map.cs
+++ b/ChaosChess_v2/Assets/Script/Map/Map.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChaosChess.Unity.AIIntegration.Cards;
 using UnityEngine;
 
 // 노드 종류: Normal(일반 전투), Elite(강화 전투), Boss(보스전)
@@ -10,6 +11,10 @@ public class Map
 {
     public int ELO;             // 이 노드의 AI 강도 (Fairy Stockfish SetElo에 직접 전달)
     public string FEN;          // 이 노드의 초기 보드 배치 (FEN 문자열)
+    public AiDeckConfig AiDeckConfig; // 이 노드에서 AI가 사용할 덱
+    public string AiDeckId;     // 저장/복원용 덱 식별자
+    public List<string> AiRuntimeDeckCardIds = new(); // 전체 카드 풀에서 뽑은 노드 전용 덱
+    public List<GameObject> AiRuntimeDeckCards = new();
     public string MapName;      // 맵 이름 (UI 표시용)
     public bool isCleared;      // 플레이어가 클리어했는지 여부
     public int floor;           // 층 번호 (0-based)

--- a/ChaosChess_v2/Assets/Script/Map/MapManager.cs
+++ b/ChaosChess_v2/Assets/Script/Map/MapManager.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
+using ChaosChess.Unity.AIIntegration.Cards;
 
 public enum PracticeDifficulty
 {
@@ -26,6 +27,15 @@ public class MapManager : MonoBehaviour
     public List<string> Boss1FEN = new();
     public List<string> Boss2FEN = new();
 
+    [Header("AI Deck")]
+    [SerializeField] private AiDeckConfig defaultAiDeckConfig;
+    [SerializeField] private AiDeckConfig normalAiDeckConfig;
+    [SerializeField] private AiDeckConfig eliteAiDeckConfig;
+    [SerializeField] private AiDeckConfig bossAiDeckConfig;
+    [SerializeField] private List<AiDeckConfig> aiDeckRegistry = new();
+    [SerializeField] private bool generateRandomAiDeckPerNode = true;
+    [SerializeField, Min(1)] private int randomAiDeckCardCount = 8;
+
     [Header("Practice")]
     [SerializeField] private int easyPracticeELO = 900;
     [SerializeField] private int normalPracticeELO = 1200;
@@ -33,6 +43,9 @@ public class MapManager : MonoBehaviour
     [SerializeField] private string easyPracticeFEN;
     [SerializeField] private string normalPracticeFEN;
     [SerializeField] private string hardPracticeFEN;
+    [SerializeField] private AiDeckConfig easyPracticeAiDeckConfig;
+    [SerializeField] private AiDeckConfig normalPracticeAiDeckConfig;
+    [SerializeField] private AiDeckConfig hardPracticeAiDeckConfig;
 
     [Header("Graph Map")]
     public int nodesPerFloorMin = 1;
@@ -80,7 +93,10 @@ public class MapManager : MonoBehaviour
             for (int col = 0; col < nodesPerFloor[floor]; col++)
             {
                 bool isBoss = floor == totalFloors - 1;
-                mapGrid[floor].nodes.Add(new Map
+                NodeType nodeType = isBoss ? NodeType.Boss
+                               : (Random.value < 0.3f ? NodeType.Elite : NodeType.Normal);
+                AiDeckConfig aiDeck = SelectAiDeckConfig(nodeType);
+                Map node = new Map
                 {
                     // 층이 높을수록 ELO 150씩 상승 → AI 강도 선형 증가
                     ELO = startELO + 150 * floor,
@@ -90,12 +106,15 @@ public class MapManager : MonoBehaviour
                     // 0층 노드만 초기에 접근 가능
                     isAccessible = floor == 0,
                     // 보스층이면 Boss, 30% 확률로 Elite, 나머지는 Normal
-                    nodeType = isBoss ? NodeType.Boss
-                               : (Random.value < 0.3f ? NodeType.Elite : NodeType.Normal),
+                    nodeType = nodeType,
                     MapName = isBoss ? $"{floor + 1}구간 보스" :
                                 $"{floor + 1}구간 - ",
-                    FEN = SelectFEN(floor, isBoss)
-                });
+                    FEN = SelectFEN(floor, isBoss),
+                    AiDeckConfig = aiDeck,
+                    AiDeckId = GetDeckId(aiDeck)
+                };
+                AssignRandomRuntimeDeck(node);
+                mapGrid[floor].nodes.Add(node);
                 if (mapGrid[floor].nodes[col].nodeType == NodeType.Elite)
                     // 추후 문자열 최적화 시 개선
                     mapGrid[floor].nodes[col].MapName += "엘리트 노드";
@@ -217,6 +236,241 @@ public class MapManager : MonoBehaviour
     {
         map.ELO = GetPracticeElo(difficulty);
         map.FEN = GetPracticeFen(difficulty);
+        map.AiDeckConfig = null;
+        map.AiDeckId = null;
+        AssignRandomRuntimeDeck(map, useAllCards: true);
+    }
+
+    public AiDeckConfig ResolveAiDeckConfig(Map map)
+    {
+        if (map == null)
+            return defaultAiDeckConfig;
+
+        if (GameCycleManager.Instance != null && GameCycleManager.Instance.IsPracticeMode)
+            return null;
+
+        if (map.AiDeckConfig != null)
+            return map.AiDeckConfig;
+
+        map.AiDeckConfig = FindAiDeckConfig(map.AiDeckId) ?? SelectAiDeckConfig(map.nodeType);
+        map.AiDeckId = GetDeckId(map.AiDeckConfig);
+        return map.AiDeckConfig;
+    }
+
+    public IReadOnlyList<GameObject> ResolveAiRuntimeDeckCards(Map map)
+    {
+        if (map == null)
+            return System.Array.Empty<GameObject>();
+
+        if (map.AiRuntimeDeckCards == null)
+            map.AiRuntimeDeckCards = new List<GameObject>();
+
+        map.AiRuntimeDeckCards.RemoveAll(card => card == null);
+        if (map.AiRuntimeDeckCards.Count > 0)
+            return map.AiRuntimeDeckCards;
+
+        if (map.AiRuntimeDeckCardIds != null && map.AiRuntimeDeckCardIds.Count > 0)
+        {
+            foreach (string cardId in map.AiRuntimeDeckCardIds)
+            {
+                GameObject card = FindAiSupportedCardById(cardId);
+                if (card != null && !ContainsSameCard(map.AiRuntimeDeckCards, card))
+                    map.AiRuntimeDeckCards.Add(card);
+            }
+        }
+
+        if (map.AiRuntimeDeckCards.Count == 0)
+            AssignRandomRuntimeDeck(map);
+
+        return map.AiRuntimeDeckCards;
+    }
+
+    public string GetRuntimeDeckKey(Map map)
+    {
+        if (map == null)
+            return "runtime_no_map";
+
+        string ids = map.AiRuntimeDeckCardIds != null
+            ? string.Join(",", map.AiRuntimeDeckCardIds)
+            : string.Empty;
+        return $"runtime_node:{map.floor}:{map.column}:{ids}";
+    }
+
+    private AiDeckConfig SelectAiDeckConfig(NodeType nodeType)
+    {
+        AiDeckConfig selected = null;
+        switch (nodeType)
+        {
+            case NodeType.Elite:
+                selected = eliteAiDeckConfig;
+                break;
+            case NodeType.Boss:
+                selected = bossAiDeckConfig;
+                break;
+            default:
+                selected = normalAiDeckConfig;
+                break;
+        }
+
+        return selected != null ? selected : defaultAiDeckConfig;
+    }
+
+    private AiDeckConfig GetPracticeAiDeckConfig(PracticeDifficulty difficulty)
+    {
+        AiDeckConfig selected = null;
+        switch (difficulty)
+        {
+            case PracticeDifficulty.Easy:
+                selected = easyPracticeAiDeckConfig;
+                break;
+            case PracticeDifficulty.Normal:
+                selected = normalPracticeAiDeckConfig;
+                break;
+            case PracticeDifficulty.Hard:
+                selected = hardPracticeAiDeckConfig;
+                break;
+        }
+
+        return selected != null ? selected : defaultAiDeckConfig;
+    }
+
+    private AiDeckConfig FindAiDeckConfig(string deckId)
+    {
+        if (string.IsNullOrWhiteSpace(deckId))
+            return null;
+
+        AiDeckConfig found = MatchesDeckId(defaultAiDeckConfig, deckId) ? defaultAiDeckConfig : null;
+        found ??= MatchesDeckId(normalAiDeckConfig, deckId) ? normalAiDeckConfig : null;
+        found ??= MatchesDeckId(eliteAiDeckConfig, deckId) ? eliteAiDeckConfig : null;
+        found ??= MatchesDeckId(bossAiDeckConfig, deckId) ? bossAiDeckConfig : null;
+        found ??= MatchesDeckId(easyPracticeAiDeckConfig, deckId) ? easyPracticeAiDeckConfig : null;
+        found ??= MatchesDeckId(normalPracticeAiDeckConfig, deckId) ? normalPracticeAiDeckConfig : null;
+        found ??= MatchesDeckId(hardPracticeAiDeckConfig, deckId) ? hardPracticeAiDeckConfig : null;
+
+        if (found != null)
+            return found;
+
+        foreach (AiDeckConfig config in aiDeckRegistry)
+        {
+            if (MatchesDeckId(config, deckId))
+                return config;
+        }
+
+        return null;
+    }
+
+    private static bool MatchesDeckId(AiDeckConfig config, string deckId)
+    {
+        return config != null && config.DeckId == deckId;
+    }
+
+    private static string GetDeckId(AiDeckConfig config)
+    {
+        return config != null ? config.DeckId : null;
+    }
+
+    private void AssignRandomRuntimeDeck(Map map, bool useAllCards = false)
+    {
+        if (map == null || !generateRandomAiDeckPerNode)
+            return;
+
+        List<GameObject> candidates = GetAllAiSupportedCards();
+        Shuffle(candidates);
+
+        int count = useAllCards ? candidates.Count : Mathf.Min(Mathf.Max(1, randomAiDeckCardCount), candidates.Count);
+        map.AiRuntimeDeckCards = new List<GameObject>(count);
+        map.AiRuntimeDeckCardIds = new List<string>(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            GameObject card = candidates[i];
+            if (card == null || !TryGetAiCardId(card, out string cardId))
+                continue;
+
+            map.AiRuntimeDeckCards.Add(card);
+            map.AiRuntimeDeckCardIds.Add(cardId);
+        }
+    }
+
+    private static List<GameObject> GetAllAiSupportedCards()
+    {
+        var cards = new List<GameObject>();
+        CardRandomizerManager manager = CardRandomizerManager.Instance;
+        if (manager == null || manager.AllCards == null)
+            return cards;
+
+        foreach (GameObject card in manager.AllCards)
+        {
+            if (card != null &&
+                TryGetAiCardId(card, out _) &&
+                !ContainsSameCard(cards, card))
+            {
+                cards.Add(card);
+            }
+        }
+
+        return cards;
+    }
+
+    private static GameObject FindAiSupportedCardById(string cardId)
+    {
+        if (string.IsNullOrWhiteSpace(cardId))
+            return null;
+
+        CardRandomizerManager manager = CardRandomizerManager.Instance;
+        if (manager == null || manager.AllCards == null)
+            return null;
+
+        foreach (GameObject card in manager.AllCards)
+        {
+            if (TryGetAiCardId(card, out string candidateId) && candidateId == cardId)
+                return card;
+        }
+
+        return null;
+    }
+
+    private static bool TryGetAiCardId(GameObject card, out string cardId)
+    {
+        cardId = null;
+        CardData cardData = card != null ? card.GetComponent<CardData>() : null;
+        CardDataSO dataSO = cardData != null ? cardData.DataSO : null;
+        if (dataSO == null ||
+            !dataSO.AiSupported ||
+            string.IsNullOrWhiteSpace(dataSO.AiCardId) ||
+            dataSO.AiCategory == AiCardCategory.Unknown)
+        {
+            return false;
+        }
+
+        cardId = dataSO.AiCardId;
+        return true;
+    }
+
+    private static bool ContainsSameCard(IEnumerable<GameObject> cards, GameObject card)
+    {
+        if (cards == null || card == null)
+            return false;
+
+        foreach (GameObject existing in cards)
+        {
+            if (ChaosChess.Unity.AIIntegration.Cards.AiCardHand.IsSameCard(existing, card))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static void Shuffle(List<GameObject> cards)
+    {
+        if (cards == null)
+            return;
+
+        for (int i = cards.Count - 1; i > 0; i--)
+        {
+            int j = Random.Range(0, i + 1);
+            (cards[i], cards[j]) = (cards[j], cards[i]);
+        }
     }
 
     /// <summary>
@@ -254,7 +508,10 @@ public class MapManager : MonoBehaviour
                         nextColumns = nodeData.nextColumns != null ? new System.Collections.Generic.List<int>(nodeData.nextColumns) : new System.Collections.Generic.List<int>(),
                         isAccessible = nodeData.isAccessible,
                         uiPosition = new UnityEngine.Vector2(nodeData.uiPositionX, nodeData.uiPositionY),
-                        nodeType = (NodeType)nodeData.nodeType
+                        nodeType = (NodeType)nodeData.nodeType,
+                        AiDeckId = nodeData.aiDeckId,
+                        AiDeckConfig = FindAiDeckConfig(nodeData.aiDeckId),
+                        AiRuntimeDeckCardIds = nodeData.aiRuntimeDeckCardIds != null ? new List<string>(nodeData.aiRuntimeDeckCardIds) : new List<string>()
                     });
                 }
                 mapGrid.Add(floor);

--- a/ChaosChess_v2/Assets/Script/Save/RunSaveData.cs
+++ b/ChaosChess_v2/Assets/Script/Save/RunSaveData.cs
@@ -25,6 +25,8 @@ public class MapNodeSaveData
 {
     public int elo;
     public string fen;
+    public string aiDeckId;
+    public List<string> aiRuntimeDeckCardIds = new();
     public string mapName;
     public bool isCleared;
     public int floor;

--- a/ChaosChess_v2/Assets/Script/Save/SaveManager.cs
+++ b/ChaosChess_v2/Assets/Script/Save/SaveManager.cs
@@ -213,6 +213,12 @@ public class SaveManager : MonoBehaviour
                 {
                     elo = node.ELO,
                     fen = node.FEN,
+                    aiDeckId = !string.IsNullOrWhiteSpace(node.AiDeckId)
+                        ? node.AiDeckId
+                        : node.AiDeckConfig != null ? node.AiDeckConfig.DeckId : null,
+                    aiRuntimeDeckCardIds = node.AiRuntimeDeckCardIds != null
+                        ? new List<string>(node.AiRuntimeDeckCardIds)
+                        : new List<string>(),
                     mapName = node.MapName,
                     isCleared = node.isCleared,
                     floor = node.floor,

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardAnim.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardAnim.cs
@@ -55,9 +55,21 @@ public class CardAnim : MonoBehaviour
 
     public void EnableCardDataUI()
     {
+        if (cardData == null || cardData.DataSO == null)
+        {
+            CardBlockNotifier.Notify(CardBlockReason.MissingCardData);
+            return;
+        }
+
         if (CardSelectionState.IsLocked)
         {
             CardBlockNotifier.Notify(CardBlockReason.SelectionInProgress);
+            return;
+        }
+
+        if (!CardUseRules.CanUseForCurrentPlayer(cardData.DataSO, requireCardInHand: false, containsCard: null, out CardBlockReason reason))
+        {
+            CardBlockNotifier.Notify(reason);
             return;
         }
 

--- a/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
+++ b/ChaosChess_v2/Assets/Script/UI/Ingame/CardDescPanel.cs
@@ -94,6 +94,11 @@ public class CardDescPanel : ButtonPanel
                 if (gameManager == null) gameManager = GameManager.Instance;
                 gameManager?.CancelCurrentSelectionForBoardTransition();
                 DisablePanel();
+                if (!CardUseRules.CanUseForCurrentPlayer(data.DataSO, requireCardInHand: false, containsCard: null, out CardBlockReason reason))
+                {
+                    CardBlockNotifier.Notify(reason, data.DataSO != null ? data.DataSO.CardName : null);
+                    return;
+                }
                 cardExecute?.Invoke();
             }
         );


### PR DESCRIPTION
## 개요

AI 카드 사용 흐름을 고정 손패/디버그 중심에서 실제 게임용 덱/손패 런타임 기반으로 전환합니다.

이번 PR은 AI가 현재 보유한 손패만 기준으로 카드를 판단하고, 플레이어와 동일한 카드 사용 제한 규칙을 거치도록 Unity 런타임 경계를 정리하는 단계입니다.

## Related to

- Closes 8x8-Labs/Chaos-Chess-v2#307
- parent: 8x8-Labs/Chaos-Chess-v2#304

## 변경 내용

- 플레이어/AI가 공유하는 `CardUseRules` 추가
- 체크/턴/게임 종료/투기장/손패 보유 여부 기반 카드 사용 제한 동기화
- `AiDeckConfig` / `AiDeckRuntime` 기반 AI 덱/손패 런타임 추가
- AI 턴 시작 시 초기 손패 및 주기 드로우 처리 연결
- AI 카드 플래너가 현재 AI 손패만 후보로 사용하도록 정리
- 카드 사용 후 AI 손패/used pile 상태가 갱신되도록 실행 경계 보강
- 맵 노드별 AI 런타임 덱 생성 및 저장/복원 연동
- 일반 런은 노드마다 전체 AI 지원 카드 중 랜덤 덱 생성
- 연습모드는 전체 AI 지원 카드 풀을 AI 덱으로 사용
- AI Card Debugger에 노드별 AI 덱 확인용 `Decks` 탭 추가
- `MainGameScene`, `MainGameScene_AITest`에 AI 카드 시스템 연결

## 제외 범위

- 카드별 AI 평가 점수 튜닝
- ChaosChess.AI core 변경
- 신규 카드 효과 구현
- 덱 빌딩 화면 제작
- 카드 UI 대규모 개편
- 밸런스 확정
- Unity Play Mode 자동 테스트 추가
- `ProjectSettings/GvhProjectSettings.xml`
- `ChaosChess_v2.slnx`